### PR TITLE
Fix header z-index property to prevent overlap with mobile menu

### DIFF
--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -16,7 +16,7 @@ export default function Header() {
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false)
 
   return (
-      <header className="absolute inset-x-0 top-0 z-50">
+      <header className="absolute inset-x-0 top-0 z-10">
         <nav className="flex items-center justify-between p-6 lg:px-8" aria-label="Global">
           <div className="flex lg:flex-1">
             <a href="/" className="-m-1.5 p-1.5">


### PR DESCRIPTION
This pull request addresses the issue of header and mobile menu overlap by adjusting the z-index property. Now, the header properly layers below the mobile menu, ensuring a seamless user experience across devices.

Steps to Reproduce:
1. Access the website/application on a mobile device or resize the browser window to simulate a mobile viewport.
2. Tap/click on the mobile menu icon (top right corner) to expand the menu.

Screenshot:
![Screen Shot 2024-05-04 at 11 33 05](https://github.com/operately/website/assets/4091095/13906548-868d-4ef2-bd55-f13250d7244a)

