### PR TITLE
[WIP] The Open Source Playbook

### DIFF
--- a/src/pages/open_source_playbook.mdx
+++ b/src/pages/open_source_playbook.mdx
@@ -1,0 +1,146 @@
+---
+layout: '../layouts/Article.astro'
+title: "The Operately Open Source Playbook"
+---
+
+Operately is an open company, with an open-source product.
+
+We strongly believe in the power of community and the impact it can have on building 
+and scaling successful startups. By building in the open, we build a community of 
+founders, operators, and builders who can collaborate, share insights and best 
+practices, and support one another in their journey toward success.
+
+# Making Open Source Truly Open
+
+Software development is too often shrouded in secrecy. Fake open-source projects
+are popping up everywhere, with companies claiming to be open-source while keeping
+their development process and decision-making behind closed doors. Contributing to
+such projects is like throwing code over a wall and hoping it sticks.
+
+True open-source isn't just about openinig up the codebase. It's about opening up
+every decision, every conversation, every plan, and every piece of information
+that can help the community understand the project and contribute to it. It's about
+building a community that is as much a part of the project as the core team.
+
+Building in the open is hard. It requires discipline, transparency, and a willingness
+to be vulnerable. But the rewards are immense. By building in the open, we can
+leverage the collective intelligence of the community, build trust, and create a
+sustainable product that can outlast any single contributor or company.
+
+# The Operately Open Source Playbook
+
+This playbook is a living document that outlines how we build and operate Operately
+as an open-source company. It covers everything from how we make decisions to how
+we communicate, collaborate, and build our product. 
+
+What follows is a set of principles and practices that guide our work.
+
+## Build in Public, For Real
+
+If we’re serious about open source, we’ve got to go all-in on building in
+public. This means our process isn’t just behind-the-scenes decision making 
+it’s open, visible, and transparent. People can follow along, give feedback, 
+and steer Operately by engaging with us in real-time.
+
+What does this look like in practice?
+
+- **Open Code**: Our code is open-source, and we welcome contributions from the community.
+- **Open Design**: We share our design process, from wireframes to final designs.
+- **Open Issues**: Our issue tracker is open, and we encourage the community to report bugs and suggest features.
+- **Open Roadmaps**: Our roadmap is public, and we actively seek feedback on it.
+- **Open Discussions**: We discuss our decisions, challenges, and learnings in the open.
+- **Open Documentation**: Our documentation is open, and we encourage the community to help improve it.
+
+## Communicate in Public
+
+Communication is the lifeblood of any organization, and in an open-source organization,
+it’s even more critical. We strive to communicate openly, honestly, and transparently
+with the community, our contributors, and each other.
+
+What does this look like in practice?
+
+- **Public Meetings**: We hold public meetings where anyone can join and participate even if they're not part of the core team.
+- **Public Discord Channels**: We use public Discord channels for real-time communication.
+- **Live meetings are recorded**: We record all meetings and make them available to the rest of the community via the Operately Backstage YouTube channel.
+- **Devlogs**: The core team records weekly devlogs to share what they've been working on and what they've learned.
+- **No Direct Messages**: We avoid direct messages for work-related communication and use public channels instead.
+- **Public standups**: We hold public standups, it is open to everyone, not just the core team.
+
+## Make contributing effortless
+
+We want to make it as easy as possible for people to contribute to Operately.
+This means lowering the barrier to entry, providing clear guidelines, and
+offering support and mentorship to new contributors. If you want to contribute
+to Operately, our job is to make it easy for you.
+
+What does this look like in practice?
+
+- **Contributor Guidelines**: We have clear guidelines on how to contribute to Operately.
+- **Good First Issues**: We tag issues that are good for first-time contributors and maintain a list of them.
+- **Mentorship**: We offer mentorship to new contributors to help them get started.
+- **Code Reviews**: We provide constructive feedback on all contributions and help contributors improve their work.
+- **Recognition**: We recognize and celebrate the contributions of all our contributors.
+- **Community Calls**: We hold regular community calls where contributors can ask questions, share ideas, and get to know the core team.
+- **Reporting Security Issues**: We have a clear process for reporting security issues and a responsible disclosure policy.
+
+## Make it cool to be a contributor
+
+Contributing to Operately shouldn’t just feel like work—it should feel
+exciting. People should want to be a part of what we’re building. That happens
+when contributors feel seen, appreciated, and proud of the impact they’re
+making.
+
+What does this look like in practice?
+
+- **Swag**: We send swag to our top contributors to thank them for their hard work.
+- **Bug Bounties**: We offer bug bounties to reward contributors for finding and fixing bugs.
+- **Contributor Events**: We host contributor events, like hackathons and meetups, to bring the community together.
+- **Hangout channels**: We have public hangout channels where contributors can chat, share memes, and get to know each other. A fun cat gif can go a long way.
+- **Take Contributors Seriously**: We treat contributors with respect and take their feedback and ideas seriously.
+- **Hacktoberfest**: We participate in Hacktoberfest and encourage our contributors to do the same.
+
+## Track, Learn, and Improve
+
+Building in the open is an ongoing process of iteration and improvement. We beleive
+that it is impossible to get everything right the first time. We track our progress,
+learn from our mistakes, and constantly seek to improve our processes and practices.
+
+We track contributions, community engagement, and the health of open-source.
+
+- **Openess Score**: We track our open-source efforts using a scorecard.
+- **Contributions**: We track the number of contributions, contributors, and pull requests to measure community involvement.
+- **GitHub Stars**: We track the number of GitHub stars, forks, and issues to measure community engagement.
+
+### Openness Score
+
+We keep a scorecard of our open-source efforts:
+
+- [1 point] - Open codebase
+- [1 point] - Open design process
+- [1 point] - Open issue tracker
+- [1 point] - Open roadmap
+- [1 point] - Open discussions
+
+- [1 point] - Public meetings
+- [1 point] - Public discord channels for development
+- [1 point] - Meeting are recorded and shared on YouTube
+- [1 point] - Devlogs
+- [1 point] - No direct messages for development-related communication
+- [1 point] - Public standups
+
+- [1 point] - Contributor guidelines is up-to-date
+- [1 point] - Good first issues are tagged and up-to-date
+- [1 point] - Mentorship program is in place
+- [1 point] - Code reviews are quick and constructive for all contributions
+- [1 point] - Contributors are recognized and celebrated
+- [1 point] - Regular community calls
+- [1 point] - Security issue reporting process is clear
+
+- [1 point] - Swag for top contributors
+- [1 point] - Bug bounties
+- [1 point] - Contributor events
+- [1 point] - Public hangout channels
+- [1 point] - Hacktoberfest, or similar event participation
+
+In total, we aim to score 25 points every week. If we fall short, we reflect on
+what went wrong, learn from it, and make improvements for the next week.


### PR DESCRIPTION
This PR reflects my conversation with @markoa today about open-source and building in public. Marko rightly pointed out that we can and should be more open.

Originally I planned to simply open a google document and write down some ideas, but as I was writing, the format of the document evolved and it become a writeup of where I envision us in the upcoming future. Some points in the document area already true, but some areas are a good reminder that we can do better.

For example:

- Marko and me discuss product development via DMs. There is no good reason why, it is simply a habit that we continued to this day. These conversations are a goldmine of ideas, various product directions, and a log of all the micro-decisions that make Operately great. They should be public.

- The same situation with Adriano. We have long and detailed discussions about development decisions daily. A truckload of great ideas is born and dies in that DM conversation that we have on Discord. Again, there is no real reason why it is behind closed doors. It should be public and open to contributors.

- Whimsical wireframes are closed. No real reason for that.

- We should record our live conversations for Youtube Backstage. This can be a bit more painful until we are used to it, but once we are, it will be an excellent logbook to look back at.

---

I wrote down things that were seemed like obvious wins at the moment that we can archive with relative ease, but there are probably many other good ideas where we can expand after we sleep on it for a day or two.

cc-ing @markoa and @Rockyy174 for review and comments.

---

Writing down questions and todos for me:

- [ ] Should this be part of the website? 🤔
- [ ] What about conferences? 
- [ ] What about meetups, internships, google summer of code, local and global scene?
- [ ] GitLab is awesome at open-source, what can we learn from them?
- [ ] How should we handle security reports?
- [ ] Where to keep KPIs for this?