### PR TITLE
Feature latest release on homepage, GitHub star widget

### DIFF
--- a/src/components/Buttons.jsx
+++ b/src/components/Buttons.jsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+export const GitHubStarButton = ({ username, repo }) => {
+  return (
+    <a href={`https://github.com/${username}/${repo}`} target="_blank" rel="noopener noreferrer">
+      <img 
+        alt="GitHub stars" 
+        src={`https://img.shields.io/github/stars/${username}/${repo}?style=social`}
+      />
+    </a>
+  );
+};

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -42,7 +42,7 @@ export default function Header() {
         <div className="hidden lg:flex lg:flex-1 lg:justify-end">
           <div className="hidden lg:flex items-center gap-x-6">
             {navigation.map((item) => (
-              <a key={item.name} href={item.href} className="text-sm font-semibold leading-6 text-gray-900">
+              <a key={item.name} href={item.href} className="text-sm font-semibold leading-6 text-gray-900 hover:text-operately-blue">
                 {item.name}
               </a>
             ))}

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -4,6 +4,7 @@ const releasesCollection = defineCollection({
   type: 'content',
   schema: z.object({
     title: z.string(),
+    version: z.string(),
     description: z.string(),
     date: z.date(),
     published: z.boolean(),

--- a/src/content/releases/release-v0.1.0.mdx
+++ b/src/content/releases/release-v0.1.0.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Operately v0.1: The First Public Alpha Release"
+version: "0.1"
 date: 2024-09-02
 description: "Celebrating the first public self-hostable release of Operately!"
 published: true

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,21 +1,26 @@
 ---
-import BaseLayout from '../layouts/BaseLayout.astro';
+import BaseLayout from "../layouts/BaseLayout.astro";
 
 const pageTitle = "The Open Source Startup Operating System";
-const pageDescription = "You don't need a COO. You need Operately. Run your projects, goals, and processes like a high performance startup.";
+const pageDescription =
+  "You don't need a COO. You need Operately. Run your projects, goals, and processes like a high performance startup.";
 
-import Hero from './index/Hero.jsx';
-import Intro from './index/Intro.jsx';
+import Hero from "./index/Hero.jsx";
+import Intro from "./index/Intro.jsx";
+
+import { getLatestRelease } from "../utils/releases";
+
+const latestRelease = await getLatestRelease();
 ---
 
 <BaseLayout
   title={pageTitle}
   description={pageDescription}
   image={"/images/social/card-summary-large.png"}
-  twitterCardType="summary_large_image">
-
+  twitterCardType="summary_large_image"
+>
   <main>
-    <Hero client:load />
+    <Hero client:load latestRelease={latestRelease} />
     <Intro client:load />
   </main>
-</Layout>
+</BaseLayout>

--- a/src/pages/index/Hero.jsx
+++ b/src/pages/index/Hero.jsx
@@ -22,10 +22,10 @@ export default function Hero({ latestRelease }) {
 
           <div className="text-center">
             <h1 className="text-4xl font-bold tracking-tight text-gray-900 sm:text-6xl">
-              The missing startup operating system
+              The Startup OS You've Been Missing
             </h1>
             <p className="mt-6 text-lg leading-8 text-gray-600">
-              Run your projects, goals, and processes like a high performance startup.
+              Open-source company management. Projects, goals, and processes <span class="hidden lg:inline"><br /></span> in one place.
             </p>
             <div className="mt-10 flex items-center justify-center gap-x-6">
               <JoinWaitlist />

--- a/src/pages/index/Hero.jsx
+++ b/src/pages/index/Hero.jsx
@@ -1,4 +1,4 @@
-export default function Hero() {
+export default function Hero({ latestRelease }) {
   return (
     <div className="bg-white">
       <div className="relative isolate px-6 pt-14 lg:px-8">
@@ -16,7 +16,7 @@ export default function Hero() {
           </div>
 
         <div className="mx-auto max-w-2xl py-8 sm:py-16 lg:py-32">
-          <OpenSourceBadge />
+          <LatestReleaseBadge release={latestRelease} />
 
           <div className="text-center">
             <h1 className="text-4xl font-bold tracking-tight text-gray-900 sm:text-6xl">
@@ -49,12 +49,14 @@ export default function Hero() {
   )
 }
 
-function OpenSourceBadge() {
-  <div className="hidden sm:mb-8 sm:flex sm:justify-center">
-    <div className="relative rounded-full px-3 py-1 text-sm leading-6 text-gray-600 ring-1 ring-gray-900/10 hover:ring-gray-900/20">
-      100% Open Source
+function LatestReleaseBadge({ release }) {
+  return (
+    <div className="mb-4 sm:mb-8 flex justify-center">
+      <div className="relative rounded-full px-3 py-1 text-sm leading-6 text-gray-600 ring-1 ring-gray-900/10 hover:ring-gray-900/20">
+        🚀 Operately {release.version} now available - <a href={`/releases/${release.slug}`} className="text-operately-blue hover:text-operately-dark-blue">See what's new</a>
+      </div>
     </div>
-  </div>
+  );
 }
 
 function JoinWaitlist() {

--- a/src/pages/index/Hero.jsx
+++ b/src/pages/index/Hero.jsx
@@ -1,3 +1,5 @@
+import { GitHubStarButton } from '../../components/Buttons';
+
 export default function Hero({ latestRelease }) {
   return (
     <div className="bg-white">
@@ -51,10 +53,11 @@ export default function Hero({ latestRelease }) {
 
 function LatestReleaseBadge({ release }) {
   return (
-    <div className="mb-4 sm:mb-8 flex justify-center">
+    <div className="mb-4 sm:mb-8 flex flex-col sm:flex-row items-center justify-center space-y-2 sm:space-y-0 sm:space-x-4">
       <div className="relative rounded-full px-3 py-1 text-sm leading-6 text-gray-600 ring-1 ring-gray-900/10 hover:ring-gray-900/20">
-        🚀 Operately {release.version} now available - <a href={`/releases/${release.slug}`} className="text-operately-blue hover:text-operately-dark-blue">See what's new</a>
+        🚀 Operately {release.version} now available - <a href={`/releases/${release.slug}`} className="text-operately-blue hover:text-operately-dark-blue">See what's new →</a>
       </div>
+      <GitHubStarButton username="operately" repo="operately" />
     </div>
   );
 }

--- a/src/utils/releases.js
+++ b/src/utils/releases.js
@@ -1,12 +1,17 @@
 import { getCollection } from 'astro:content';
 
-export async function getPublishedReleases() {
-  const allReleases = await getCollection('releases');
-  
-  // If we're not in dev mode, we're gonna skip non-published releases
-  const isProduction = !import.meta.env.DEV;
+export async function getLatestRelease() {
+  const allReleases = await getCollection('releases', ({ data }) => {
+    return data.published === true;
+  });
 
-  return allReleases.filter(release => 
-    isProduction ? release.data.published !== false : true
-  ).sort((a, b) => b.data.date.valueOf() - a.data.date.valueOf());
+  const latestRelease = allReleases.sort((a, b) => b.data.date.valueOf() - a.data.date.valueOf())[0];
+
+  if (!latestRelease) return null;
+
+  return {
+    version: latestRelease.data.version,
+    slug: latestRelease.slug,
+    date: latestRelease.data.date.toISOString()
+  };
 }

--- a/src/utils/releases.js
+++ b/src/utils/releases.js
@@ -15,3 +15,14 @@ export async function getLatestRelease() {
     date: latestRelease.data.date.toISOString()
   };
 }
+
+export async function getPublishedReleases() {
+  const allReleases = await getCollection('releases');
+  
+  // If we're not in dev mode, we're gonna skip non-published releases
+  const isProduction = !import.meta.env.DEV;
+
+  return allReleases.filter(release => 
+    isProduction ? release.data.published !== false : true
+  ).sort((a, b) => b.data.date.valueOf() - a.data.date.valueOf());
+}


### PR DESCRIPTION
@shiroyasha please note that I've extended the schema of releases so from now on defining a `version` string is mandatory.

Also tweaked the hero copy a bit. Here's what the hero looks like now:

<img width="822" alt="Screenshot 2024-10-02 at 12 13 21" src="https://github.com/user-attachments/assets/05644395-2df1-48be-8b9a-768ff9cb6146">
