### PR TITLE
Fix popover on hover and on click issues in navigation

### DIFF
--- a/src/components/Navigation.jsx
+++ b/src/components/Navigation.jsx
@@ -103,7 +103,7 @@ export default function Navigation() {
         <PopoverGroup className="hidden lg:flex lg:gap-x-8">
           {/* Product menu */}
           <Popover className="relative">
-            <PopoverButton className="flex items-center gap-x-1 text-sm/6 font-semibold text-gray-900">
+            <PopoverButton className="flex items-center gap-x-1 text-sm/6 font-semibold text-gray-900 cursor-pointer focus:outline-none">
               Product
               <ChevronDown
                 aria-hidden="true"
@@ -149,7 +149,7 @@ export default function Navigation() {
 
           {/* About menu */}
           <Popover className="relative">
-            <PopoverButton className="flex items-center gap-x-1 text-sm/6 font-semibold text-gray-900">
+            <PopoverButton className="flex items-center gap-x-1 text-sm/6 font-semibold text-gray-900 cursor-pointer focus:outline-none">
               About
               <ChevronDown
                 aria-hidden="true"


### PR DESCRIPTION
- Added `cursor-pointer` to both Product and About menu buttons, this will make the cursor change to a hand pointer on hover.
- Added `focus:outline-none` to both menu buttons, this removes the blue border that appears when clicking on the links.