### PR TITLE
Improve help docs SEO metadata

### DIFF
--- a/src/content/docs/help/add-external-link/index.mdx
+++ b/src/content/docs/help/add-external-link/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Add an External Link"
-description: "Add an link to an external service or document."
+description: "Add a link to an external service, website, or document."
 ---
 
 import ImageEnhancer from '@/components/ImageEnhancer.astro';

--- a/src/content/docs/help/api/comments/create.mdx
+++ b/src/content/docs/help/api/comments/create.mdx
@@ -1,6 +1,6 @@
 ---
-title: "create"
-description: "Generated reference for the mutation endpoint comments/create."
+title: "Comments API: Create"
+description: "Reference for the create mutation in the Comments API."
 ---
 
 import CurlExampleBlock from "@components/CurlExampleBlock.jsx"

--- a/src/content/docs/help/api/comments/delete.mdx
+++ b/src/content/docs/help/api/comments/delete.mdx
@@ -1,6 +1,6 @@
 ---
-title: "delete"
-description: "Generated reference for the mutation endpoint comments/delete."
+title: "Comments API: Delete"
+description: "Reference for the delete mutation in the Comments API."
 ---
 
 import CurlExampleBlock from "@components/CurlExampleBlock.jsx"

--- a/src/content/docs/help/api/comments/index.mdx
+++ b/src/content/docs/help/api/comments/index.mdx
@@ -1,6 +1,6 @@
 ---
-title: API Comments
-description: Generated endpoint reference for the Comments namespace.
+title: "Comments API"
+description: "Endpoint reference for comments in the Operately API."
 ---
 
 List, create and manage comments on resources
@@ -18,28 +18,28 @@ List, create and manage comments on resources
     </thead>
     <tbody>
       <tr>
-  <td><a href="./create">create</a></td>
+  <td><a href="./create">Create</a></td>
   <td><code>POST</code></td>
   <td><code>mutation</code></td>
   <td><code>/api/external/v1/comments/create</code></td>
 </tr>
 
 <tr>
-  <td><a href="./delete">delete</a></td>
+  <td><a href="./delete">Delete</a></td>
   <td><code>POST</code></td>
   <td><code>mutation</code></td>
   <td><code>/api/external/v1/comments/delete</code></td>
 </tr>
 
 <tr>
-  <td><a href="./list">list</a></td>
+  <td><a href="./list">List</a></td>
   <td><code>GET</code></td>
   <td><code>query</code></td>
   <td><code>/api/external/v1/comments/list</code></td>
 </tr>
 
 <tr>
-  <td><a href="./update">update</a></td>
+  <td><a href="./update">Update</a></td>
   <td><code>POST</code></td>
   <td><code>mutation</code></td>
   <td><code>/api/external/v1/comments/update</code></td>

--- a/src/content/docs/help/api/comments/list.mdx
+++ b/src/content/docs/help/api/comments/list.mdx
@@ -1,6 +1,6 @@
 ---
-title: "list"
-description: "Generated reference for the query endpoint comments/list."
+title: "Comments API: List"
+description: "Reference for the list query in the Comments API."
 ---
 
 import CurlExampleBlock from "@components/CurlExampleBlock.jsx"

--- a/src/content/docs/help/api/comments/update.mdx
+++ b/src/content/docs/help/api/comments/update.mdx
@@ -1,6 +1,6 @@
 ---
-title: "update"
-description: "Generated reference for the mutation endpoint comments/update."
+title: "Comments API: Update"
+description: "Reference for the update mutation in the Comments API."
 ---
 
 import CurlExampleBlock from "@components/CurlExampleBlock.jsx"

--- a/src/content/docs/help/api/companies/convert_member_to_guest.mdx
+++ b/src/content/docs/help/api/companies/convert_member_to_guest.mdx
@@ -1,6 +1,6 @@
 ---
-title: "convert_member_to_guest"
-description: "Generated reference for the mutation endpoint companies/convert_member_to_guest."
+title: "Companies API: Convert member to guest"
+description: "Reference for the convert member to guest mutation in the Companies API."
 ---
 
 import CurlExampleBlock from "@components/CurlExampleBlock.jsx"

--- a/src/content/docs/help/api/companies/create.mdx
+++ b/src/content/docs/help/api/companies/create.mdx
@@ -1,6 +1,6 @@
 ---
-title: "create"
-description: "Generated reference for the mutation endpoint companies/create."
+title: "Companies API: Create"
+description: "Reference for the create mutation in the Companies API."
 ---
 
 import CurlExampleBlock from "@components/CurlExampleBlock.jsx"

--- a/src/content/docs/help/api/companies/create_admins.mdx
+++ b/src/content/docs/help/api/companies/create_admins.mdx
@@ -1,6 +1,6 @@
 ---
-title: "create_admins"
-description: "Generated reference for the mutation endpoint companies/create_admins."
+title: "Companies API: Create admins"
+description: "Reference for the create admins mutation in the Companies API."
 ---
 
 import CurlExampleBlock from "@components/CurlExampleBlock.jsx"

--- a/src/content/docs/help/api/companies/create_member.mdx
+++ b/src/content/docs/help/api/companies/create_member.mdx
@@ -1,6 +1,6 @@
 ---
-title: "create_member"
-description: "Generated reference for the mutation endpoint companies/create_member."
+title: "Companies API: Create member"
+description: "Reference for the create member mutation in the Companies API."
 ---
 
 import CurlExampleBlock from "@components/CurlExampleBlock.jsx"

--- a/src/content/docs/help/api/companies/delete_admin.mdx
+++ b/src/content/docs/help/api/companies/delete_admin.mdx
@@ -1,6 +1,6 @@
 ---
-title: "delete_admin"
-description: "Generated reference for the mutation endpoint companies/delete_admin."
+title: "Companies API: Delete admin"
+description: "Reference for the delete admin mutation in the Companies API."
 ---
 
 import CurlExampleBlock from "@components/CurlExampleBlock.jsx"

--- a/src/content/docs/help/api/companies/delete_member.mdx
+++ b/src/content/docs/help/api/companies/delete_member.mdx
@@ -1,6 +1,6 @@
 ---
-title: "delete_member"
-description: "Generated reference for the mutation endpoint companies/delete_member."
+title: "Companies API: Delete member"
+description: "Reference for the delete member mutation in the Companies API."
 ---
 
 import CurlExampleBlock from "@components/CurlExampleBlock.jsx"

--- a/src/content/docs/help/api/companies/delete_owner.mdx
+++ b/src/content/docs/help/api/companies/delete_owner.mdx
@@ -1,6 +1,6 @@
 ---
-title: "delete_owner"
-description: "Generated reference for the mutation endpoint companies/delete_owner."
+title: "Companies API: Delete owner"
+description: "Reference for the delete owner mutation in the Companies API."
 ---
 
 import CurlExampleBlock from "@components/CurlExampleBlock.jsx"

--- a/src/content/docs/help/api/companies/delete_trusted_email_domain.mdx
+++ b/src/content/docs/help/api/companies/delete_trusted_email_domain.mdx
@@ -1,6 +1,6 @@
 ---
-title: "delete_trusted_email_domain"
-description: "Generated reference for the mutation endpoint companies/delete_trusted_email_domain."
+title: "Companies API: Delete trusted email domain"
+description: "Reference for the delete trusted email domain mutation in the Companies API."
 ---
 
 import CurlExampleBlock from "@components/CurlExampleBlock.jsx"

--- a/src/content/docs/help/api/companies/get.mdx
+++ b/src/content/docs/help/api/companies/get.mdx
@@ -1,6 +1,6 @@
 ---
-title: "get"
-description: "Generated reference for the query endpoint companies/get."
+title: "Companies API: Get"
+description: "Reference for the get query in the Companies API."
 ---
 
 import CurlExampleBlock from "@components/CurlExampleBlock.jsx"

--- a/src/content/docs/help/api/companies/get_activity.mdx
+++ b/src/content/docs/help/api/companies/get_activity.mdx
@@ -1,6 +1,6 @@
 ---
-title: "get_activity"
-description: "Generated reference for the query endpoint companies/get_activity."
+title: "Companies API: Get activity"
+description: "Reference for the get activity query in the Companies API."
 ---
 
 import CurlExampleBlock from "@components/CurlExampleBlock.jsx"

--- a/src/content/docs/help/api/companies/get_flat_work_map.mdx
+++ b/src/content/docs/help/api/companies/get_flat_work_map.mdx
@@ -1,6 +1,6 @@
 ---
-title: "get_flat_work_map"
-description: "Generated reference for the query endpoint companies/get_flat_work_map."
+title: "Companies API: Get flat work map"
+description: "Reference for the get flat work map query in the Companies API."
 ---
 
 import CurlExampleBlock from "@components/CurlExampleBlock.jsx"

--- a/src/content/docs/help/api/companies/get_work_map.mdx
+++ b/src/content/docs/help/api/companies/get_work_map.mdx
@@ -1,6 +1,6 @@
 ---
-title: "get_work_map"
-description: "Generated reference for the query endpoint companies/get_work_map."
+title: "Companies API: Get work map"
+description: "Reference for the get work map query in the Companies API."
 ---
 
 import CurlExampleBlock from "@components/CurlExampleBlock.jsx"

--- a/src/content/docs/help/api/companies/global_search.mdx
+++ b/src/content/docs/help/api/companies/global_search.mdx
@@ -1,6 +1,6 @@
 ---
-title: "global_search"
-description: "Generated reference for the query endpoint companies/global_search."
+title: "Companies API: Global search"
+description: "Reference for the global search query in the Companies API."
 ---
 
 import CurlExampleBlock from "@components/CurlExampleBlock.jsx"

--- a/src/content/docs/help/api/companies/grant_resource_access.mdx
+++ b/src/content/docs/help/api/companies/grant_resource_access.mdx
@@ -1,6 +1,6 @@
 ---
-title: "grant_resource_access"
-description: "Generated reference for the mutation endpoint companies/grant_resource_access."
+title: "Companies API: Grant resource access"
+description: "Reference for the grant resource access mutation in the Companies API."
 ---
 
 import CurlExampleBlock from "@components/CurlExampleBlock.jsx"

--- a/src/content/docs/help/api/companies/index.mdx
+++ b/src/content/docs/help/api/companies/index.mdx
@@ -1,6 +1,6 @@
 ---
-title: API Companies
-description: Generated endpoint reference for the Companies namespace.
+title: "Companies API"
+description: "Endpoint reference for companies in the Operately API."
 ---
 
 Get, list, update and manage company settings, members, and permissions
@@ -18,140 +18,140 @@ Get, list, update and manage company settings, members, and permissions
     </thead>
     <tbody>
       <tr>
-  <td><a href="./convert_member_to_guest">convert_member_to_guest</a></td>
+  <td><a href="./convert_member_to_guest">Convert member to guest</a></td>
   <td><code>POST</code></td>
   <td><code>mutation</code></td>
   <td><code>/api/external/v1/companies/convert_member_to_guest</code></td>
 </tr>
 
 <tr>
-  <td><a href="./create">create</a></td>
+  <td><a href="./create">Create</a></td>
   <td><code>POST</code></td>
   <td><code>mutation</code></td>
   <td><code>/api/external/v1/companies/create</code></td>
 </tr>
 
 <tr>
-  <td><a href="./create_admins">create_admins</a></td>
+  <td><a href="./create_admins">Create admins</a></td>
   <td><code>POST</code></td>
   <td><code>mutation</code></td>
   <td><code>/api/external/v1/companies/create_admins</code></td>
 </tr>
 
 <tr>
-  <td><a href="./create_member">create_member</a></td>
+  <td><a href="./create_member">Create member</a></td>
   <td><code>POST</code></td>
   <td><code>mutation</code></td>
   <td><code>/api/external/v1/companies/create_member</code></td>
 </tr>
 
 <tr>
-  <td><a href="./delete_admin">delete_admin</a></td>
+  <td><a href="./delete_admin">Delete admin</a></td>
   <td><code>POST</code></td>
   <td><code>mutation</code></td>
   <td><code>/api/external/v1/companies/delete_admin</code></td>
 </tr>
 
 <tr>
-  <td><a href="./delete_member">delete_member</a></td>
+  <td><a href="./delete_member">Delete member</a></td>
   <td><code>POST</code></td>
   <td><code>mutation</code></td>
   <td><code>/api/external/v1/companies/delete_member</code></td>
 </tr>
 
 <tr>
-  <td><a href="./delete_owner">delete_owner</a></td>
+  <td><a href="./delete_owner">Delete owner</a></td>
   <td><code>POST</code></td>
   <td><code>mutation</code></td>
   <td><code>/api/external/v1/companies/delete_owner</code></td>
 </tr>
 
 <tr>
-  <td><a href="./delete_trusted_email_domain">delete_trusted_email_domain</a></td>
+  <td><a href="./delete_trusted_email_domain">Delete trusted email domain</a></td>
   <td><code>POST</code></td>
   <td><code>mutation</code></td>
   <td><code>/api/external/v1/companies/delete_trusted_email_domain</code></td>
 </tr>
 
 <tr>
-  <td><a href="./get">get</a></td>
+  <td><a href="./get">Get</a></td>
   <td><code>GET</code></td>
   <td><code>query</code></td>
   <td><code>/api/external/v1/companies/get</code></td>
 </tr>
 
 <tr>
-  <td><a href="./get_activity">get_activity</a></td>
+  <td><a href="./get_activity">Get activity</a></td>
   <td><code>GET</code></td>
   <td><code>query</code></td>
   <td><code>/api/external/v1/companies/get_activity</code></td>
 </tr>
 
 <tr>
-  <td><a href="./get_flat_work_map">get_flat_work_map</a></td>
+  <td><a href="./get_flat_work_map">Get flat work map</a></td>
   <td><code>GET</code></td>
   <td><code>query</code></td>
   <td><code>/api/external/v1/companies/get_flat_work_map</code></td>
 </tr>
 
 <tr>
-  <td><a href="./get_work_map">get_work_map</a></td>
+  <td><a href="./get_work_map">Get work map</a></td>
   <td><code>GET</code></td>
   <td><code>query</code></td>
   <td><code>/api/external/v1/companies/get_work_map</code></td>
 </tr>
 
 <tr>
-  <td><a href="./global_search">global_search</a></td>
+  <td><a href="./global_search">Global search</a></td>
   <td><code>GET</code></td>
   <td><code>query</code></td>
   <td><code>/api/external/v1/companies/global_search</code></td>
 </tr>
 
 <tr>
-  <td><a href="./grant_resource_access">grant_resource_access</a></td>
+  <td><a href="./grant_resource_access">Grant resource access</a></td>
   <td><code>POST</code></td>
   <td><code>mutation</code></td>
   <td><code>/api/external/v1/companies/grant_resource_access</code></td>
 </tr>
 
 <tr>
-  <td><a href="./invite_guest">invite_guest</a></td>
+  <td><a href="./invite_guest">Invite guest</a></td>
   <td><code>POST</code></td>
   <td><code>mutation</code></td>
   <td><code>/api/external/v1/companies/invite_guest</code></td>
 </tr>
 
 <tr>
-  <td><a href="./list">list</a></td>
+  <td><a href="./list">List</a></td>
   <td><code>GET</code></td>
   <td><code>query</code></td>
   <td><code>/api/external/v1/companies/list</code></td>
 </tr>
 
 <tr>
-  <td><a href="./list_activities">list_activities</a></td>
+  <td><a href="./list_activities">List activities</a></td>
   <td><code>GET</code></td>
   <td><code>query</code></td>
   <td><code>/api/external/v1/companies/list_activities</code></td>
 </tr>
 
 <tr>
-  <td><a href="./restore_member">restore_member</a></td>
+  <td><a href="./restore_member">Restore member</a></td>
   <td><code>POST</code></td>
   <td><code>mutation</code></td>
   <td><code>/api/external/v1/companies/restore_member</code></td>
 </tr>
 
 <tr>
-  <td><a href="./update">update</a></td>
+  <td><a href="./update">Update</a></td>
   <td><code>POST</code></td>
   <td><code>mutation</code></td>
   <td><code>/api/external/v1/companies/update</code></td>
 </tr>
 
 <tr>
-  <td><a href="./update_members_permissions">update_members_permissions</a></td>
+  <td><a href="./update_members_permissions">Update members permissions</a></td>
   <td><code>POST</code></td>
   <td><code>mutation</code></td>
   <td><code>/api/external/v1/companies/update_members_permissions</code></td>

--- a/src/content/docs/help/api/companies/invite_guest.mdx
+++ b/src/content/docs/help/api/companies/invite_guest.mdx
@@ -1,6 +1,6 @@
 ---
-title: "invite_guest"
-description: "Generated reference for the mutation endpoint companies/invite_guest."
+title: "Companies API: Invite guest"
+description: "Reference for the invite guest mutation in the Companies API."
 ---
 
 import CurlExampleBlock from "@components/CurlExampleBlock.jsx"

--- a/src/content/docs/help/api/companies/list.mdx
+++ b/src/content/docs/help/api/companies/list.mdx
@@ -1,6 +1,6 @@
 ---
-title: "list"
-description: "Generated reference for the query endpoint companies/list."
+title: "Companies API: List"
+description: "Reference for the list query in the Companies API."
 ---
 
 import CurlExampleBlock from "@components/CurlExampleBlock.jsx"

--- a/src/content/docs/help/api/companies/list_activities.mdx
+++ b/src/content/docs/help/api/companies/list_activities.mdx
@@ -1,6 +1,6 @@
 ---
-title: "list_activities"
-description: "Generated reference for the query endpoint companies/list_activities."
+title: "Companies API: List activities"
+description: "Reference for the list activities query in the Companies API."
 ---
 
 import CurlExampleBlock from "@components/CurlExampleBlock.jsx"

--- a/src/content/docs/help/api/companies/restore_member.mdx
+++ b/src/content/docs/help/api/companies/restore_member.mdx
@@ -1,6 +1,6 @@
 ---
-title: "restore_member"
-description: "Generated reference for the mutation endpoint companies/restore_member."
+title: "Companies API: Restore member"
+description: "Reference for the restore member mutation in the Companies API."
 ---
 
 import CurlExampleBlock from "@components/CurlExampleBlock.jsx"

--- a/src/content/docs/help/api/companies/update.mdx
+++ b/src/content/docs/help/api/companies/update.mdx
@@ -1,6 +1,6 @@
 ---
-title: "update"
-description: "Generated reference for the mutation endpoint companies/update."
+title: "Companies API: Update"
+description: "Reference for the update mutation in the Companies API."
 ---
 
 import CurlExampleBlock from "@components/CurlExampleBlock.jsx"

--- a/src/content/docs/help/api/companies/update_members_permissions.mdx
+++ b/src/content/docs/help/api/companies/update_members_permissions.mdx
@@ -1,6 +1,6 @@
 ---
-title: "update_members_permissions"
-description: "Generated reference for the mutation endpoint companies/update_members_permissions."
+title: "Companies API: Update members permissions"
+description: "Reference for the update members permissions mutation in the Companies API."
 ---
 
 import CurlExampleBlock from "@components/CurlExampleBlock.jsx"

--- a/src/content/docs/help/api/documents/create.mdx
+++ b/src/content/docs/help/api/documents/create.mdx
@@ -1,6 +1,6 @@
 ---
-title: "create"
-description: "Generated reference for the mutation endpoint documents/create."
+title: "Documents API: Create"
+description: "Reference for the create mutation in the Documents API."
 ---
 
 import CurlExampleBlock from "@components/CurlExampleBlock.jsx"

--- a/src/content/docs/help/api/documents/delete.mdx
+++ b/src/content/docs/help/api/documents/delete.mdx
@@ -1,6 +1,6 @@
 ---
-title: "delete"
-description: "Generated reference for the mutation endpoint documents/delete."
+title: "Documents API: Delete"
+description: "Reference for the delete mutation in the Documents API."
 ---
 
 import CurlExampleBlock from "@components/CurlExampleBlock.jsx"

--- a/src/content/docs/help/api/documents/get.mdx
+++ b/src/content/docs/help/api/documents/get.mdx
@@ -1,6 +1,6 @@
 ---
-title: "get"
-description: "Generated reference for the query endpoint documents/get."
+title: "Documents API: Get"
+description: "Reference for the get query in the Documents API."
 ---
 
 import CurlExampleBlock from "@components/CurlExampleBlock.jsx"

--- a/src/content/docs/help/api/documents/index.mdx
+++ b/src/content/docs/help/api/documents/index.mdx
@@ -1,6 +1,6 @@
 ---
-title: API Documents
-description: Generated endpoint reference for the Documents namespace.
+title: "Documents API"
+description: "Endpoint reference for documents in the Operately API."
 ---
 
 Get, create and manage documents in resource hubs
@@ -18,35 +18,35 @@ Get, create and manage documents in resource hubs
     </thead>
     <tbody>
       <tr>
-  <td><a href="./create">create</a></td>
+  <td><a href="./create">Create</a></td>
   <td><code>POST</code></td>
   <td><code>mutation</code></td>
   <td><code>/api/external/v1/documents/create</code></td>
 </tr>
 
 <tr>
-  <td><a href="./delete">delete</a></td>
+  <td><a href="./delete">Delete</a></td>
   <td><code>POST</code></td>
   <td><code>mutation</code></td>
   <td><code>/api/external/v1/documents/delete</code></td>
 </tr>
 
 <tr>
-  <td><a href="./get">get</a></td>
+  <td><a href="./get">Get</a></td>
   <td><code>GET</code></td>
   <td><code>query</code></td>
   <td><code>/api/external/v1/documents/get</code></td>
 </tr>
 
 <tr>
-  <td><a href="./publish">publish</a></td>
+  <td><a href="./publish">Publish</a></td>
   <td><code>POST</code></td>
   <td><code>mutation</code></td>
   <td><code>/api/external/v1/documents/publish</code></td>
 </tr>
 
 <tr>
-  <td><a href="./update">update</a></td>
+  <td><a href="./update">Update</a></td>
   <td><code>POST</code></td>
   <td><code>mutation</code></td>
   <td><code>/api/external/v1/documents/update</code></td>

--- a/src/content/docs/help/api/documents/publish.mdx
+++ b/src/content/docs/help/api/documents/publish.mdx
@@ -1,6 +1,6 @@
 ---
-title: "publish"
-description: "Generated reference for the mutation endpoint documents/publish."
+title: "Documents API: Publish"
+description: "Reference for the publish mutation in the Documents API."
 ---
 
 import CurlExampleBlock from "@components/CurlExampleBlock.jsx"

--- a/src/content/docs/help/api/documents/update.mdx
+++ b/src/content/docs/help/api/documents/update.mdx
@@ -1,6 +1,6 @@
 ---
-title: "update"
-description: "Generated reference for the mutation endpoint documents/update."
+title: "Documents API: Update"
+description: "Reference for the update mutation in the Documents API."
 ---
 
 import CurlExampleBlock from "@components/CurlExampleBlock.jsx"

--- a/src/content/docs/help/api/goals/acknowledge_check_in.mdx
+++ b/src/content/docs/help/api/goals/acknowledge_check_in.mdx
@@ -1,6 +1,6 @@
 ---
-title: "acknowledge_check_in"
-description: "Generated reference for the mutation endpoint goals/acknowledge_check_in."
+title: "Goals API: Acknowledge check-in"
+description: "Reference for the acknowledge check-in mutation in the Goals API."
 ---
 
 import CurlExampleBlock from "@components/CurlExampleBlock.jsx"

--- a/src/content/docs/help/api/goals/change_parent.mdx
+++ b/src/content/docs/help/api/goals/change_parent.mdx
@@ -1,6 +1,6 @@
 ---
-title: "change_parent"
-description: "Generated reference for the mutation endpoint goals/change_parent."
+title: "Goals API: Change parent"
+description: "Reference for the change parent mutation in the Goals API."
 ---
 
 import CurlExampleBlock from "@components/CurlExampleBlock.jsx"

--- a/src/content/docs/help/api/goals/close.mdx
+++ b/src/content/docs/help/api/goals/close.mdx
@@ -1,6 +1,6 @@
 ---
-title: "close"
-description: "Generated reference for the mutation endpoint goals/close."
+title: "Goals API: Close"
+description: "Reference for the close mutation in the Goals API."
 ---
 
 import CurlExampleBlock from "@components/CurlExampleBlock.jsx"

--- a/src/content/docs/help/api/goals/create.mdx
+++ b/src/content/docs/help/api/goals/create.mdx
@@ -1,6 +1,6 @@
 ---
-title: "create"
-description: "Generated reference for the mutation endpoint goals/create."
+title: "Goals API: Create"
+description: "Reference for the create mutation in the Goals API."
 ---
 
 import CurlExampleBlock from "@components/CurlExampleBlock.jsx"

--- a/src/content/docs/help/api/goals/create_access_members.mdx
+++ b/src/content/docs/help/api/goals/create_access_members.mdx
@@ -1,6 +1,6 @@
 ---
-title: "create_access_members"
-description: "Generated reference for the mutation endpoint goals/create_access_members."
+title: "Goals API: Create access members"
+description: "Reference for the create access members mutation in the Goals API."
 ---
 
 import CurlExampleBlock from "@components/CurlExampleBlock.jsx"

--- a/src/content/docs/help/api/goals/create_check.mdx
+++ b/src/content/docs/help/api/goals/create_check.mdx
@@ -1,6 +1,6 @@
 ---
-title: "create_check"
-description: "Generated reference for the mutation endpoint goals/create_check."
+title: "Goals API: Create check"
+description: "Reference for the create check mutation in the Goals API."
 ---
 
 import CurlExampleBlock from "@components/CurlExampleBlock.jsx"

--- a/src/content/docs/help/api/goals/create_check_in.mdx
+++ b/src/content/docs/help/api/goals/create_check_in.mdx
@@ -1,6 +1,6 @@
 ---
-title: "create_check_in"
-description: "Generated reference for the mutation endpoint goals/create_check_in."
+title: "Goals API: Create check-in"
+description: "Reference for the create check-in mutation in the Goals API."
 ---
 
 import CurlExampleBlock from "@components/CurlExampleBlock.jsx"

--- a/src/content/docs/help/api/goals/create_discussion.mdx
+++ b/src/content/docs/help/api/goals/create_discussion.mdx
@@ -1,6 +1,6 @@
 ---
-title: "create_discussion"
-description: "Generated reference for the mutation endpoint goals/create_discussion."
+title: "Goals API: Create discussion"
+description: "Reference for the create discussion mutation in the Goals API."
 ---
 
 import CurlExampleBlock from "@components/CurlExampleBlock.jsx"

--- a/src/content/docs/help/api/goals/create_target.mdx
+++ b/src/content/docs/help/api/goals/create_target.mdx
@@ -1,6 +1,6 @@
 ---
-title: "create_target"
-description: "Generated reference for the mutation endpoint goals/create_target."
+title: "Goals API: Create target"
+description: "Reference for the create target mutation in the Goals API."
 ---
 
 import CurlExampleBlock from "@components/CurlExampleBlock.jsx"

--- a/src/content/docs/help/api/goals/delete.mdx
+++ b/src/content/docs/help/api/goals/delete.mdx
@@ -1,6 +1,6 @@
 ---
-title: "delete"
-description: "Generated reference for the mutation endpoint goals/delete."
+title: "Goals API: Delete"
+description: "Reference for the delete mutation in the Goals API."
 ---
 
 import CurlExampleBlock from "@components/CurlExampleBlock.jsx"

--- a/src/content/docs/help/api/goals/delete_access_member.mdx
+++ b/src/content/docs/help/api/goals/delete_access_member.mdx
@@ -1,6 +1,6 @@
 ---
-title: "delete_access_member"
-description: "Generated reference for the mutation endpoint goals/delete_access_member."
+title: "Goals API: Delete access member"
+description: "Reference for the delete access member mutation in the Goals API."
 ---
 
 import CurlExampleBlock from "@components/CurlExampleBlock.jsx"

--- a/src/content/docs/help/api/goals/delete_check.mdx
+++ b/src/content/docs/help/api/goals/delete_check.mdx
@@ -1,6 +1,6 @@
 ---
-title: "delete_check"
-description: "Generated reference for the mutation endpoint goals/delete_check."
+title: "Goals API: Delete check"
+description: "Reference for the delete check mutation in the Goals API."
 ---
 
 import CurlExampleBlock from "@components/CurlExampleBlock.jsx"

--- a/src/content/docs/help/api/goals/delete_target.mdx
+++ b/src/content/docs/help/api/goals/delete_target.mdx
@@ -1,6 +1,6 @@
 ---
-title: "delete_target"
-description: "Generated reference for the mutation endpoint goals/delete_target."
+title: "Goals API: Delete target"
+description: "Reference for the delete target mutation in the Goals API."
 ---
 
 import CurlExampleBlock from "@components/CurlExampleBlock.jsx"

--- a/src/content/docs/help/api/goals/get.mdx
+++ b/src/content/docs/help/api/goals/get.mdx
@@ -1,6 +1,6 @@
 ---
-title: "get"
-description: "Generated reference for the query endpoint goals/get."
+title: "Goals API: Get"
+description: "Reference for the get query in the Goals API."
 ---
 
 import CurlExampleBlock from "@components/CurlExampleBlock.jsx"

--- a/src/content/docs/help/api/goals/get_check_in.mdx
+++ b/src/content/docs/help/api/goals/get_check_in.mdx
@@ -1,6 +1,6 @@
 ---
-title: "get_check_in"
-description: "Generated reference for the query endpoint goals/get_check_in."
+title: "Goals API: Get check-in"
+description: "Reference for the get check-in query in the Goals API."
 ---
 
 import CurlExampleBlock from "@components/CurlExampleBlock.jsx"

--- a/src/content/docs/help/api/goals/index.mdx
+++ b/src/content/docs/help/api/goals/index.mdx
@@ -1,6 +1,6 @@
 ---
-title: API Goals
-description: Generated endpoint reference for the Goals namespace.
+title: "Goals API"
+description: "Endpoint reference for goals in the Operately API."
 ---
 
 Get, list, create and manage goals
@@ -18,280 +18,280 @@ Get, list, create and manage goals
     </thead>
     <tbody>
       <tr>
-  <td><a href="./acknowledge_check_in">acknowledge_check_in</a></td>
+  <td><a href="./acknowledge_check_in">Acknowledge check-in</a></td>
   <td><code>POST</code></td>
   <td><code>mutation</code></td>
   <td><code>/api/external/v1/goals/acknowledge_check_in</code></td>
 </tr>
 
 <tr>
-  <td><a href="./change_parent">change_parent</a></td>
+  <td><a href="./change_parent">Change parent</a></td>
   <td><code>POST</code></td>
   <td><code>mutation</code></td>
   <td><code>/api/external/v1/goals/change_parent</code></td>
 </tr>
 
 <tr>
-  <td><a href="./close">close</a></td>
+  <td><a href="./close">Close</a></td>
   <td><code>POST</code></td>
   <td><code>mutation</code></td>
   <td><code>/api/external/v1/goals/close</code></td>
 </tr>
 
 <tr>
-  <td><a href="./create">create</a></td>
+  <td><a href="./create">Create</a></td>
   <td><code>POST</code></td>
   <td><code>mutation</code></td>
   <td><code>/api/external/v1/goals/create</code></td>
 </tr>
 
 <tr>
-  <td><a href="./create_access_members">create_access_members</a></td>
+  <td><a href="./create_access_members">Create access members</a></td>
   <td><code>POST</code></td>
   <td><code>mutation</code></td>
   <td><code>/api/external/v1/goals/create_access_members</code></td>
 </tr>
 
 <tr>
-  <td><a href="./create_check">create_check</a></td>
+  <td><a href="./create_check">Create check</a></td>
   <td><code>POST</code></td>
   <td><code>mutation</code></td>
   <td><code>/api/external/v1/goals/create_check</code></td>
 </tr>
 
 <tr>
-  <td><a href="./create_check_in">create_check_in</a></td>
+  <td><a href="./create_check_in">Create check-in</a></td>
   <td><code>POST</code></td>
   <td><code>mutation</code></td>
   <td><code>/api/external/v1/goals/create_check_in</code></td>
 </tr>
 
 <tr>
-  <td><a href="./create_discussion">create_discussion</a></td>
+  <td><a href="./create_discussion">Create discussion</a></td>
   <td><code>POST</code></td>
   <td><code>mutation</code></td>
   <td><code>/api/external/v1/goals/create_discussion</code></td>
 </tr>
 
 <tr>
-  <td><a href="./create_target">create_target</a></td>
+  <td><a href="./create_target">Create target</a></td>
   <td><code>POST</code></td>
   <td><code>mutation</code></td>
   <td><code>/api/external/v1/goals/create_target</code></td>
 </tr>
 
 <tr>
-  <td><a href="./delete">delete</a></td>
+  <td><a href="./delete">Delete</a></td>
   <td><code>POST</code></td>
   <td><code>mutation</code></td>
   <td><code>/api/external/v1/goals/delete</code></td>
 </tr>
 
 <tr>
-  <td><a href="./delete_access_member">delete_access_member</a></td>
+  <td><a href="./delete_access_member">Delete access member</a></td>
   <td><code>POST</code></td>
   <td><code>mutation</code></td>
   <td><code>/api/external/v1/goals/delete_access_member</code></td>
 </tr>
 
 <tr>
-  <td><a href="./delete_check">delete_check</a></td>
+  <td><a href="./delete_check">Delete check</a></td>
   <td><code>POST</code></td>
   <td><code>mutation</code></td>
   <td><code>/api/external/v1/goals/delete_check</code></td>
 </tr>
 
 <tr>
-  <td><a href="./delete_target">delete_target</a></td>
+  <td><a href="./delete_target">Delete target</a></td>
   <td><code>POST</code></td>
   <td><code>mutation</code></td>
   <td><code>/api/external/v1/goals/delete_target</code></td>
 </tr>
 
 <tr>
-  <td><a href="./get">get</a></td>
+  <td><a href="./get">Get</a></td>
   <td><code>GET</code></td>
   <td><code>query</code></td>
   <td><code>/api/external/v1/goals/get</code></td>
 </tr>
 
 <tr>
-  <td><a href="./get_check_in">get_check_in</a></td>
+  <td><a href="./get_check_in">Get check-in</a></td>
   <td><code>GET</code></td>
   <td><code>query</code></td>
   <td><code>/api/external/v1/goals/get_check_in</code></td>
 </tr>
 
 <tr>
-  <td><a href="./list">list</a></td>
+  <td><a href="./list">List</a></td>
   <td><code>GET</code></td>
   <td><code>query</code></td>
   <td><code>/api/external/v1/goals/list</code></td>
 </tr>
 
 <tr>
-  <td><a href="./list_access_members">list_access_members</a></td>
+  <td><a href="./list_access_members">List access members</a></td>
   <td><code>GET</code></td>
   <td><code>query</code></td>
   <td><code>/api/external/v1/goals/list_access_members</code></td>
 </tr>
 
 <tr>
-  <td><a href="./list_check_ins">list_check_ins</a></td>
+  <td><a href="./list_check_ins">List check-ins</a></td>
   <td><code>GET</code></td>
   <td><code>query</code></td>
   <td><code>/api/external/v1/goals/list_check_ins</code></td>
 </tr>
 
 <tr>
-  <td><a href="./list_contributors">list_contributors</a></td>
+  <td><a href="./list_contributors">List contributors</a></td>
   <td><code>GET</code></td>
   <td><code>query</code></td>
   <td><code>/api/external/v1/goals/list_contributors</code></td>
 </tr>
 
 <tr>
-  <td><a href="./list_discussions">list_discussions</a></td>
+  <td><a href="./list_discussions">List discussions</a></td>
   <td><code>GET</code></td>
   <td><code>query</code></td>
   <td><code>/api/external/v1/goals/list_discussions</code></td>
 </tr>
 
 <tr>
-  <td><a href="./reopen">reopen</a></td>
+  <td><a href="./reopen">Reopen</a></td>
   <td><code>POST</code></td>
   <td><code>mutation</code></td>
   <td><code>/api/external/v1/goals/reopen</code></td>
 </tr>
 
 <tr>
-  <td><a href="./search_parent_goal">search_parent_goal</a></td>
+  <td><a href="./search_parent_goal">Search parent goal</a></td>
   <td><code>GET</code></td>
   <td><code>query</code></td>
   <td><code>/api/external/v1/goals/search_parent_goal</code></td>
 </tr>
 
 <tr>
-  <td><a href="./toggle_check">toggle_check</a></td>
+  <td><a href="./toggle_check">Toggle check</a></td>
   <td><code>POST</code></td>
   <td><code>mutation</code></td>
   <td><code>/api/external/v1/goals/toggle_check</code></td>
 </tr>
 
 <tr>
-  <td><a href="./update_access_levels">update_access_levels</a></td>
+  <td><a href="./update_access_levels">Update access levels</a></td>
   <td><code>POST</code></td>
   <td><code>mutation</code></td>
   <td><code>/api/external/v1/goals/update_access_levels</code></td>
 </tr>
 
 <tr>
-  <td><a href="./update_access_member">update_access_member</a></td>
+  <td><a href="./update_access_member">Update access member</a></td>
   <td><code>POST</code></td>
   <td><code>mutation</code></td>
   <td><code>/api/external/v1/goals/update_access_member</code></td>
 </tr>
 
 <tr>
-  <td><a href="./update_champion">update_champion</a></td>
+  <td><a href="./update_champion">Update champion</a></td>
   <td><code>POST</code></td>
   <td><code>mutation</code></td>
   <td><code>/api/external/v1/goals/update_champion</code></td>
 </tr>
 
 <tr>
-  <td><a href="./update_check">update_check</a></td>
+  <td><a href="./update_check">Update check</a></td>
   <td><code>POST</code></td>
   <td><code>mutation</code></td>
   <td><code>/api/external/v1/goals/update_check</code></td>
 </tr>
 
 <tr>
-  <td><a href="./update_check_in">update_check_in</a></td>
+  <td><a href="./update_check_in">Update check-in</a></td>
   <td><code>POST</code></td>
   <td><code>mutation</code></td>
   <td><code>/api/external/v1/goals/update_check_in</code></td>
 </tr>
 
 <tr>
-  <td><a href="./update_check_index">update_check_index</a></td>
+  <td><a href="./update_check_index">Update check index</a></td>
   <td><code>POST</code></td>
   <td><code>mutation</code></td>
   <td><code>/api/external/v1/goals/update_check_index</code></td>
 </tr>
 
 <tr>
-  <td><a href="./update_description">update_description</a></td>
+  <td><a href="./update_description">Update description</a></td>
   <td><code>POST</code></td>
   <td><code>mutation</code></td>
   <td><code>/api/external/v1/goals/update_description</code></td>
 </tr>
 
 <tr>
-  <td><a href="./update_discussion">update_discussion</a></td>
+  <td><a href="./update_discussion">Update discussion</a></td>
   <td><code>POST</code></td>
   <td><code>mutation</code></td>
   <td><code>/api/external/v1/goals/update_discussion</code></td>
 </tr>
 
 <tr>
-  <td><a href="./update_due_date">update_due_date</a></td>
+  <td><a href="./update_due_date">Update due date</a></td>
   <td><code>POST</code></td>
   <td><code>mutation</code></td>
   <td><code>/api/external/v1/goals/update_due_date</code></td>
 </tr>
 
 <tr>
-  <td><a href="./update_name">update_name</a></td>
+  <td><a href="./update_name">Update name</a></td>
   <td><code>POST</code></td>
   <td><code>mutation</code></td>
   <td><code>/api/external/v1/goals/update_name</code></td>
 </tr>
 
 <tr>
-  <td><a href="./update_parent_goal">update_parent_goal</a></td>
+  <td><a href="./update_parent_goal">Update parent goal</a></td>
   <td><code>POST</code></td>
   <td><code>mutation</code></td>
   <td><code>/api/external/v1/goals/update_parent_goal</code></td>
 </tr>
 
 <tr>
-  <td><a href="./update_reviewer">update_reviewer</a></td>
+  <td><a href="./update_reviewer">Update reviewer</a></td>
   <td><code>POST</code></td>
   <td><code>mutation</code></td>
   <td><code>/api/external/v1/goals/update_reviewer</code></td>
 </tr>
 
 <tr>
-  <td><a href="./update_space">update_space</a></td>
+  <td><a href="./update_space">Update space</a></td>
   <td><code>POST</code></td>
   <td><code>mutation</code></td>
   <td><code>/api/external/v1/goals/update_space</code></td>
 </tr>
 
 <tr>
-  <td><a href="./update_start_date">update_start_date</a></td>
+  <td><a href="./update_start_date">Update start date</a></td>
   <td><code>POST</code></td>
   <td><code>mutation</code></td>
   <td><code>/api/external/v1/goals/update_start_date</code></td>
 </tr>
 
 <tr>
-  <td><a href="./update_target">update_target</a></td>
+  <td><a href="./update_target">Update target</a></td>
   <td><code>POST</code></td>
   <td><code>mutation</code></td>
   <td><code>/api/external/v1/goals/update_target</code></td>
 </tr>
 
 <tr>
-  <td><a href="./update_target_index">update_target_index</a></td>
+  <td><a href="./update_target_index">Update target index</a></td>
   <td><code>POST</code></td>
   <td><code>mutation</code></td>
   <td><code>/api/external/v1/goals/update_target_index</code></td>
 </tr>
 
 <tr>
-  <td><a href="./update_target_value">update_target_value</a></td>
+  <td><a href="./update_target_value">Update target value</a></td>
   <td><code>POST</code></td>
   <td><code>mutation</code></td>
   <td><code>/api/external/v1/goals/update_target_value</code></td>

--- a/src/content/docs/help/api/goals/list.mdx
+++ b/src/content/docs/help/api/goals/list.mdx
@@ -1,6 +1,6 @@
 ---
-title: "list"
-description: "Generated reference for the query endpoint goals/list."
+title: "Goals API: List"
+description: "Reference for the list query in the Goals API."
 ---
 
 import CurlExampleBlock from "@components/CurlExampleBlock.jsx"

--- a/src/content/docs/help/api/goals/list_access_members.mdx
+++ b/src/content/docs/help/api/goals/list_access_members.mdx
@@ -1,6 +1,6 @@
 ---
-title: "list_access_members"
-description: "Generated reference for the query endpoint goals/list_access_members."
+title: "Goals API: List access members"
+description: "Reference for the list access members query in the Goals API."
 ---
 
 import CurlExampleBlock from "@components/CurlExampleBlock.jsx"

--- a/src/content/docs/help/api/goals/list_check_ins.mdx
+++ b/src/content/docs/help/api/goals/list_check_ins.mdx
@@ -1,6 +1,6 @@
 ---
-title: "list_check_ins"
-description: "Generated reference for the query endpoint goals/list_check_ins."
+title: "Goals API: List check-ins"
+description: "Reference for the list check-ins query in the Goals API."
 ---
 
 import CurlExampleBlock from "@components/CurlExampleBlock.jsx"

--- a/src/content/docs/help/api/goals/list_contributors.mdx
+++ b/src/content/docs/help/api/goals/list_contributors.mdx
@@ -1,6 +1,6 @@
 ---
-title: "list_contributors"
-description: "Generated reference for the query endpoint goals/list_contributors."
+title: "Goals API: List contributors"
+description: "Reference for the list contributors query in the Goals API."
 ---
 
 import CurlExampleBlock from "@components/CurlExampleBlock.jsx"

--- a/src/content/docs/help/api/goals/list_discussions.mdx
+++ b/src/content/docs/help/api/goals/list_discussions.mdx
@@ -1,6 +1,6 @@
 ---
-title: "list_discussions"
-description: "Generated reference for the query endpoint goals/list_discussions."
+title: "Goals API: List discussions"
+description: "Reference for the list discussions query in the Goals API."
 ---
 
 import CurlExampleBlock from "@components/CurlExampleBlock.jsx"

--- a/src/content/docs/help/api/goals/reopen.mdx
+++ b/src/content/docs/help/api/goals/reopen.mdx
@@ -1,6 +1,6 @@
 ---
-title: "reopen"
-description: "Generated reference for the mutation endpoint goals/reopen."
+title: "Goals API: Reopen"
+description: "Reference for the reopen mutation in the Goals API."
 ---
 
 import CurlExampleBlock from "@components/CurlExampleBlock.jsx"

--- a/src/content/docs/help/api/goals/search_parent_goal.mdx
+++ b/src/content/docs/help/api/goals/search_parent_goal.mdx
@@ -1,6 +1,6 @@
 ---
-title: "search_parent_goal"
-description: "Generated reference for the query endpoint goals/search_parent_goal."
+title: "Goals API: Search parent goal"
+description: "Reference for the search parent goal query in the Goals API."
 ---
 
 import CurlExampleBlock from "@components/CurlExampleBlock.jsx"

--- a/src/content/docs/help/api/goals/toggle_check.mdx
+++ b/src/content/docs/help/api/goals/toggle_check.mdx
@@ -1,6 +1,6 @@
 ---
-title: "toggle_check"
-description: "Generated reference for the mutation endpoint goals/toggle_check."
+title: "Goals API: Toggle check"
+description: "Reference for the toggle check mutation in the Goals API."
 ---
 
 import CurlExampleBlock from "@components/CurlExampleBlock.jsx"

--- a/src/content/docs/help/api/goals/update_access_levels.mdx
+++ b/src/content/docs/help/api/goals/update_access_levels.mdx
@@ -1,6 +1,6 @@
 ---
-title: "update_access_levels"
-description: "Generated reference for the mutation endpoint goals/update_access_levels."
+title: "Goals API: Update access levels"
+description: "Reference for the update access levels mutation in the Goals API."
 ---
 
 import CurlExampleBlock from "@components/CurlExampleBlock.jsx"

--- a/src/content/docs/help/api/goals/update_access_member.mdx
+++ b/src/content/docs/help/api/goals/update_access_member.mdx
@@ -1,6 +1,6 @@
 ---
-title: "update_access_member"
-description: "Generated reference for the mutation endpoint goals/update_access_member."
+title: "Goals API: Update access member"
+description: "Reference for the update access member mutation in the Goals API."
 ---
 
 import CurlExampleBlock from "@components/CurlExampleBlock.jsx"

--- a/src/content/docs/help/api/goals/update_champion.mdx
+++ b/src/content/docs/help/api/goals/update_champion.mdx
@@ -1,6 +1,6 @@
 ---
-title: "update_champion"
-description: "Generated reference for the mutation endpoint goals/update_champion."
+title: "Goals API: Update champion"
+description: "Reference for the update champion mutation in the Goals API."
 ---
 
 import CurlExampleBlock from "@components/CurlExampleBlock.jsx"

--- a/src/content/docs/help/api/goals/update_check.mdx
+++ b/src/content/docs/help/api/goals/update_check.mdx
@@ -1,6 +1,6 @@
 ---
-title: "update_check"
-description: "Generated reference for the mutation endpoint goals/update_check."
+title: "Goals API: Update check"
+description: "Reference for the update check mutation in the Goals API."
 ---
 
 import CurlExampleBlock from "@components/CurlExampleBlock.jsx"

--- a/src/content/docs/help/api/goals/update_check_in.mdx
+++ b/src/content/docs/help/api/goals/update_check_in.mdx
@@ -1,6 +1,6 @@
 ---
-title: "update_check_in"
-description: "Generated reference for the mutation endpoint goals/update_check_in."
+title: "Goals API: Update check-in"
+description: "Reference for the update check-in mutation in the Goals API."
 ---
 
 import CurlExampleBlock from "@components/CurlExampleBlock.jsx"

--- a/src/content/docs/help/api/goals/update_check_index.mdx
+++ b/src/content/docs/help/api/goals/update_check_index.mdx
@@ -1,6 +1,6 @@
 ---
-title: "update_check_index"
-description: "Generated reference for the mutation endpoint goals/update_check_index."
+title: "Goals API: Update check index"
+description: "Reference for the update check index mutation in the Goals API."
 ---
 
 import CurlExampleBlock from "@components/CurlExampleBlock.jsx"

--- a/src/content/docs/help/api/goals/update_description.mdx
+++ b/src/content/docs/help/api/goals/update_description.mdx
@@ -1,6 +1,6 @@
 ---
-title: "update_description"
-description: "Generated reference for the mutation endpoint goals/update_description."
+title: "Goals API: Update description"
+description: "Reference for the update description mutation in the Goals API."
 ---
 
 import CurlExampleBlock from "@components/CurlExampleBlock.jsx"

--- a/src/content/docs/help/api/goals/update_discussion.mdx
+++ b/src/content/docs/help/api/goals/update_discussion.mdx
@@ -1,6 +1,6 @@
 ---
-title: "update_discussion"
-description: "Generated reference for the mutation endpoint goals/update_discussion."
+title: "Goals API: Update discussion"
+description: "Reference for the update discussion mutation in the Goals API."
 ---
 
 import CurlExampleBlock from "@components/CurlExampleBlock.jsx"

--- a/src/content/docs/help/api/goals/update_due_date.mdx
+++ b/src/content/docs/help/api/goals/update_due_date.mdx
@@ -1,6 +1,6 @@
 ---
-title: "update_due_date"
-description: "Generated reference for the mutation endpoint goals/update_due_date."
+title: "Goals API: Update due date"
+description: "Reference for the update due date mutation in the Goals API."
 ---
 
 import CurlExampleBlock from "@components/CurlExampleBlock.jsx"

--- a/src/content/docs/help/api/goals/update_name.mdx
+++ b/src/content/docs/help/api/goals/update_name.mdx
@@ -1,6 +1,6 @@
 ---
-title: "update_name"
-description: "Generated reference for the mutation endpoint goals/update_name."
+title: "Goals API: Update name"
+description: "Reference for the update name mutation in the Goals API."
 ---
 
 import CurlExampleBlock from "@components/CurlExampleBlock.jsx"

--- a/src/content/docs/help/api/goals/update_parent_goal.mdx
+++ b/src/content/docs/help/api/goals/update_parent_goal.mdx
@@ -1,6 +1,6 @@
 ---
-title: "update_parent_goal"
-description: "Generated reference for the mutation endpoint goals/update_parent_goal."
+title: "Goals API: Update parent goal"
+description: "Reference for the update parent goal mutation in the Goals API."
 ---
 
 import CurlExampleBlock from "@components/CurlExampleBlock.jsx"

--- a/src/content/docs/help/api/goals/update_reviewer.mdx
+++ b/src/content/docs/help/api/goals/update_reviewer.mdx
@@ -1,6 +1,6 @@
 ---
-title: "update_reviewer"
-description: "Generated reference for the mutation endpoint goals/update_reviewer."
+title: "Goals API: Update reviewer"
+description: "Reference for the update reviewer mutation in the Goals API."
 ---
 
 import CurlExampleBlock from "@components/CurlExampleBlock.jsx"

--- a/src/content/docs/help/api/goals/update_space.mdx
+++ b/src/content/docs/help/api/goals/update_space.mdx
@@ -1,6 +1,6 @@
 ---
-title: "update_space"
-description: "Generated reference for the mutation endpoint goals/update_space."
+title: "Goals API: Update space"
+description: "Reference for the update space mutation in the Goals API."
 ---
 
 import CurlExampleBlock from "@components/CurlExampleBlock.jsx"

--- a/src/content/docs/help/api/goals/update_start_date.mdx
+++ b/src/content/docs/help/api/goals/update_start_date.mdx
@@ -1,6 +1,6 @@
 ---
-title: "update_start_date"
-description: "Generated reference for the mutation endpoint goals/update_start_date."
+title: "Goals API: Update start date"
+description: "Reference for the update start date mutation in the Goals API."
 ---
 
 import CurlExampleBlock from "@components/CurlExampleBlock.jsx"

--- a/src/content/docs/help/api/goals/update_target.mdx
+++ b/src/content/docs/help/api/goals/update_target.mdx
@@ -1,6 +1,6 @@
 ---
-title: "update_target"
-description: "Generated reference for the mutation endpoint goals/update_target."
+title: "Goals API: Update target"
+description: "Reference for the update target mutation in the Goals API."
 ---
 
 import CurlExampleBlock from "@components/CurlExampleBlock.jsx"

--- a/src/content/docs/help/api/goals/update_target_index.mdx
+++ b/src/content/docs/help/api/goals/update_target_index.mdx
@@ -1,6 +1,6 @@
 ---
-title: "update_target_index"
-description: "Generated reference for the mutation endpoint goals/update_target_index."
+title: "Goals API: Update target index"
+description: "Reference for the update target index mutation in the Goals API."
 ---
 
 import CurlExampleBlock from "@components/CurlExampleBlock.jsx"

--- a/src/content/docs/help/api/goals/update_target_value.mdx
+++ b/src/content/docs/help/api/goals/update_target_value.mdx
@@ -1,6 +1,6 @@
 ---
-title: "update_target_value"
-description: "Generated reference for the mutation endpoint goals/update_target_value."
+title: "Goals API: Update target value"
+description: "Reference for the update target value mutation in the Goals API."
 ---
 
 import CurlExampleBlock from "@components/CurlExampleBlock.jsx"

--- a/src/content/docs/help/api/index.mdx
+++ b/src/content/docs/help/api/index.mdx
@@ -1,9 +1,14 @@
 ---
-title: API docs
-description: Generated reference for Operately API endpoints.
+title: "Operately API docs"
+description: "Learn how to authenticate and use the Operately API with namespace-by-namespace endpoint reference."
 ---
 
 Operately API provides HTTP endpoints for querying and mutating Operately resources.
+
+## Start here
+
+- [Create an API token](/help/create-api-token) to authenticate your requests.
+- [Use the Operately CLI](/help/cli) if you want to work with the API from your terminal.
 
 - Every endpoint is authenticated with an API token.
 - Use the header `Authorization: Bearer <token>`.
@@ -27,6 +32,5 @@ Operately API provides HTTP endpoints for querying and mutating Operately resour
 | [Resource hubs](./resource_hubs) | 3 | 6 | 9 |
 | [Spaces](./spaces) | 10 | 14 | 24 |
 | [Tasks](./tasks) | 3 | 10 | 13 |
-
 
 

--- a/src/content/docs/help/api/links/create.mdx
+++ b/src/content/docs/help/api/links/create.mdx
@@ -1,6 +1,6 @@
 ---
-title: "create"
-description: "Generated reference for the mutation endpoint links/create."
+title: "Links API: Create"
+description: "Reference for the create mutation in the Links API."
 ---
 
 import CurlExampleBlock from "@components/CurlExampleBlock.jsx"

--- a/src/content/docs/help/api/links/delete.mdx
+++ b/src/content/docs/help/api/links/delete.mdx
@@ -1,6 +1,6 @@
 ---
-title: "delete"
-description: "Generated reference for the mutation endpoint links/delete."
+title: "Links API: Delete"
+description: "Reference for the delete mutation in the Links API."
 ---
 
 import CurlExampleBlock from "@components/CurlExampleBlock.jsx"

--- a/src/content/docs/help/api/links/get.mdx
+++ b/src/content/docs/help/api/links/get.mdx
@@ -1,6 +1,6 @@
 ---
-title: "get"
-description: "Generated reference for the query endpoint links/get."
+title: "Links API: Get"
+description: "Reference for the get query in the Links API."
 ---
 
 import CurlExampleBlock from "@components/CurlExampleBlock.jsx"

--- a/src/content/docs/help/api/links/index.mdx
+++ b/src/content/docs/help/api/links/index.mdx
@@ -1,6 +1,6 @@
 ---
-title: API Links
-description: Generated endpoint reference for the Links namespace.
+title: "Links API"
+description: "Endpoint reference for links in the Operately API."
 ---
 
 Get, create and manage links in resource hubs
@@ -18,28 +18,28 @@ Get, create and manage links in resource hubs
     </thead>
     <tbody>
       <tr>
-  <td><a href="./create">create</a></td>
+  <td><a href="./create">Create</a></td>
   <td><code>POST</code></td>
   <td><code>mutation</code></td>
   <td><code>/api/external/v1/links/create</code></td>
 </tr>
 
 <tr>
-  <td><a href="./delete">delete</a></td>
+  <td><a href="./delete">Delete</a></td>
   <td><code>POST</code></td>
   <td><code>mutation</code></td>
   <td><code>/api/external/v1/links/delete</code></td>
 </tr>
 
 <tr>
-  <td><a href="./get">get</a></td>
+  <td><a href="./get">Get</a></td>
   <td><code>GET</code></td>
   <td><code>query</code></td>
   <td><code>/api/external/v1/links/get</code></td>
 </tr>
 
 <tr>
-  <td><a href="./update">update</a></td>
+  <td><a href="./update">Update</a></td>
   <td><code>POST</code></td>
   <td><code>mutation</code></td>
   <td><code>/api/external/v1/links/update</code></td>

--- a/src/content/docs/help/api/links/update.mdx
+++ b/src/content/docs/help/api/links/update.mdx
@@ -1,6 +1,6 @@
 ---
-title: "update"
-description: "Generated reference for the mutation endpoint links/update."
+title: "Links API: Update"
+description: "Reference for the update mutation in the Links API."
 ---
 
 import CurlExampleBlock from "@components/CurlExampleBlock.jsx"

--- a/src/content/docs/help/api/notifications/get_unread_count.mdx
+++ b/src/content/docs/help/api/notifications/get_unread_count.mdx
@@ -1,6 +1,6 @@
 ---
-title: "get_unread_count"
-description: "Generated reference for the query endpoint notifications/get_unread_count."
+title: "Notifications API: Get unread count"
+description: "Reference for the get unread count query in the Notifications API."
 ---
 
 import CurlExampleBlock from "@components/CurlExampleBlock.jsx"

--- a/src/content/docs/help/api/notifications/index.mdx
+++ b/src/content/docs/help/api/notifications/index.mdx
@@ -1,6 +1,6 @@
 ---
-title: API Notifications
-description: Generated endpoint reference for the Notifications namespace.
+title: "Notifications API"
+description: "Endpoint reference for notifications in the Operately API."
 ---
 
 List and manage notifications and subscriptions
@@ -18,63 +18,63 @@ List and manage notifications and subscriptions
     </thead>
     <tbody>
       <tr>
-  <td><a href="./get_unread_count">get_unread_count</a></td>
+  <td><a href="./get_unread_count">Get unread count</a></td>
   <td><code>GET</code></td>
   <td><code>query</code></td>
   <td><code>/api/external/v1/notifications/get_unread_count</code></td>
 </tr>
 
 <tr>
-  <td><a href="./is_subscribed">is_subscribed</a></td>
+  <td><a href="./is_subscribed">Is subscribed</a></td>
   <td><code>GET</code></td>
   <td><code>query</code></td>
   <td><code>/api/external/v1/notifications/is_subscribed</code></td>
 </tr>
 
 <tr>
-  <td><a href="./list">list</a></td>
+  <td><a href="./list">List</a></td>
   <td><code>GET</code></td>
   <td><code>query</code></td>
   <td><code>/api/external/v1/notifications/list</code></td>
 </tr>
 
 <tr>
-  <td><a href="./mark_all_as_read">mark_all_as_read</a></td>
+  <td><a href="./mark_all_as_read">Mark all as read</a></td>
   <td><code>POST</code></td>
   <td><code>mutation</code></td>
   <td><code>/api/external/v1/notifications/mark_all_as_read</code></td>
 </tr>
 
 <tr>
-  <td><a href="./mark_as_read">mark_as_read</a></td>
+  <td><a href="./mark_as_read">Mark as read</a></td>
   <td><code>POST</code></td>
   <td><code>mutation</code></td>
   <td><code>/api/external/v1/notifications/mark_as_read</code></td>
 </tr>
 
 <tr>
-  <td><a href="./mark_many_as_read">mark_many_as_read</a></td>
+  <td><a href="./mark_many_as_read">Mark many as read</a></td>
   <td><code>POST</code></td>
   <td><code>mutation</code></td>
   <td><code>/api/external/v1/notifications/mark_many_as_read</code></td>
 </tr>
 
 <tr>
-  <td><a href="./subscribe">subscribe</a></td>
+  <td><a href="./subscribe">Subscribe</a></td>
   <td><code>POST</code></td>
   <td><code>mutation</code></td>
   <td><code>/api/external/v1/notifications/subscribe</code></td>
 </tr>
 
 <tr>
-  <td><a href="./unsubscribe">unsubscribe</a></td>
+  <td><a href="./unsubscribe">Unsubscribe</a></td>
   <td><code>POST</code></td>
   <td><code>mutation</code></td>
   <td><code>/api/external/v1/notifications/unsubscribe</code></td>
 </tr>
 
 <tr>
-  <td><a href="./update_subscriptions_list">update_subscriptions_list</a></td>
+  <td><a href="./update_subscriptions_list">Update subscriptions list</a></td>
   <td><code>POST</code></td>
   <td><code>mutation</code></td>
   <td><code>/api/external/v1/notifications/update_subscriptions_list</code></td>

--- a/src/content/docs/help/api/notifications/is_subscribed.mdx
+++ b/src/content/docs/help/api/notifications/is_subscribed.mdx
@@ -1,6 +1,6 @@
 ---
-title: "is_subscribed"
-description: "Generated reference for the query endpoint notifications/is_subscribed."
+title: "Notifications API: Is subscribed"
+description: "Reference for the is subscribed query in the Notifications API."
 ---
 
 import CurlExampleBlock from "@components/CurlExampleBlock.jsx"

--- a/src/content/docs/help/api/notifications/list.mdx
+++ b/src/content/docs/help/api/notifications/list.mdx
@@ -1,6 +1,6 @@
 ---
-title: "list"
-description: "Generated reference for the query endpoint notifications/list."
+title: "Notifications API: List"
+description: "Reference for the list query in the Notifications API."
 ---
 
 import CurlExampleBlock from "@components/CurlExampleBlock.jsx"

--- a/src/content/docs/help/api/notifications/mark_all_as_read.mdx
+++ b/src/content/docs/help/api/notifications/mark_all_as_read.mdx
@@ -1,6 +1,6 @@
 ---
-title: "mark_all_as_read"
-description: "Generated reference for the mutation endpoint notifications/mark_all_as_read."
+title: "Notifications API: Mark all as read"
+description: "Reference for the mark all as read mutation in the Notifications API."
 ---
 
 import CurlExampleBlock from "@components/CurlExampleBlock.jsx"

--- a/src/content/docs/help/api/notifications/mark_as_read.mdx
+++ b/src/content/docs/help/api/notifications/mark_as_read.mdx
@@ -1,6 +1,6 @@
 ---
-title: "mark_as_read"
-description: "Generated reference for the mutation endpoint notifications/mark_as_read."
+title: "Notifications API: Mark as read"
+description: "Reference for the mark as read mutation in the Notifications API."
 ---
 
 import CurlExampleBlock from "@components/CurlExampleBlock.jsx"

--- a/src/content/docs/help/api/notifications/mark_many_as_read.mdx
+++ b/src/content/docs/help/api/notifications/mark_many_as_read.mdx
@@ -1,6 +1,6 @@
 ---
-title: "mark_many_as_read"
-description: "Generated reference for the mutation endpoint notifications/mark_many_as_read."
+title: "Notifications API: Mark many as read"
+description: "Reference for the mark many as read mutation in the Notifications API."
 ---
 
 import CurlExampleBlock from "@components/CurlExampleBlock.jsx"

--- a/src/content/docs/help/api/notifications/subscribe.mdx
+++ b/src/content/docs/help/api/notifications/subscribe.mdx
@@ -1,6 +1,6 @@
 ---
-title: "subscribe"
-description: "Generated reference for the mutation endpoint notifications/subscribe."
+title: "Notifications API: Subscribe"
+description: "Reference for the subscribe mutation in the Notifications API."
 ---
 
 import CurlExampleBlock from "@components/CurlExampleBlock.jsx"

--- a/src/content/docs/help/api/notifications/unsubscribe.mdx
+++ b/src/content/docs/help/api/notifications/unsubscribe.mdx
@@ -1,6 +1,6 @@
 ---
-title: "unsubscribe"
-description: "Generated reference for the mutation endpoint notifications/unsubscribe."
+title: "Notifications API: Unsubscribe"
+description: "Reference for the unsubscribe mutation in the Notifications API."
 ---
 
 import CurlExampleBlock from "@components/CurlExampleBlock.jsx"

--- a/src/content/docs/help/api/notifications/update_subscriptions_list.mdx
+++ b/src/content/docs/help/api/notifications/update_subscriptions_list.mdx
@@ -1,6 +1,6 @@
 ---
-title: "update_subscriptions_list"
-description: "Generated reference for the mutation endpoint notifications/update_subscriptions_list."
+title: "Notifications API: Update subscriptions list"
+description: "Reference for the update subscriptions list mutation in the Notifications API."
 ---
 
 import CurlExampleBlock from "@components/CurlExampleBlock.jsx"

--- a/src/content/docs/help/api/people/get.mdx
+++ b/src/content/docs/help/api/people/get.mdx
@@ -1,6 +1,6 @@
 ---
-title: "get"
-description: "Generated reference for the query endpoint people/get."
+title: "People API: Get"
+description: "Reference for the get query in the People API."
 ---
 
 import CurlExampleBlock from "@components/CurlExampleBlock.jsx"

--- a/src/content/docs/help/api/people/get_account.mdx
+++ b/src/content/docs/help/api/people/get_account.mdx
@@ -1,6 +1,6 @@
 ---
-title: "get_account"
-description: "Generated reference for the query endpoint people/get_account."
+title: "People API: Get account"
+description: "Reference for the get account query in the People API."
 ---
 
 import CurlExampleBlock from "@components/CurlExampleBlock.jsx"

--- a/src/content/docs/help/api/people/get_assignments_count.mdx
+++ b/src/content/docs/help/api/people/get_assignments_count.mdx
@@ -1,6 +1,6 @@
 ---
-title: "get_assignments_count"
-description: "Generated reference for the query endpoint people/get_assignments_count."
+title: "People API: Get assignments count"
+description: "Reference for the get assignments count query in the People API."
 ---
 
 import CurlExampleBlock from "@components/CurlExampleBlock.jsx"

--- a/src/content/docs/help/api/people/get_binded.mdx
+++ b/src/content/docs/help/api/people/get_binded.mdx
@@ -1,6 +1,6 @@
 ---
-title: "get_binded"
-description: "Generated reference for the query endpoint people/get_binded."
+title: "People API: Get binded"
+description: "Reference for the get binded query in the People API."
 ---
 
 import CurlExampleBlock from "@components/CurlExampleBlock.jsx"

--- a/src/content/docs/help/api/people/get_me.mdx
+++ b/src/content/docs/help/api/people/get_me.mdx
@@ -1,6 +1,6 @@
 ---
-title: "get_me"
-description: "Generated reference for the query endpoint people/get_me."
+title: "People API: Get me"
+description: "Reference for the get me query in the People API."
 ---
 
 import CurlExampleBlock from "@components/CurlExampleBlock.jsx"

--- a/src/content/docs/help/api/people/index.mdx
+++ b/src/content/docs/help/api/people/index.mdx
@@ -1,6 +1,6 @@
 ---
-title: API People
-description: Generated endpoint reference for the People namespace.
+title: "People API"
+description: "Endpoint reference for people in the Operately API."
 ---
 
 Get, list, update and manage user profiles and account settings
@@ -18,84 +18,84 @@ Get, list, update and manage user profiles and account settings
     </thead>
     <tbody>
       <tr>
-  <td><a href="./get">get</a></td>
+  <td><a href="./get">Get</a></td>
   <td><code>GET</code></td>
   <td><code>query</code></td>
   <td><code>/api/external/v1/people/get</code></td>
 </tr>
 
 <tr>
-  <td><a href="./get_account">get_account</a></td>
+  <td><a href="./get_account">Get account</a></td>
   <td><code>GET</code></td>
   <td><code>query</code></td>
   <td><code>/api/external/v1/people/get_account</code></td>
 </tr>
 
 <tr>
-  <td><a href="./get_assignments_count">get_assignments_count</a></td>
+  <td><a href="./get_assignments_count">Get assignments count</a></td>
   <td><code>GET</code></td>
   <td><code>query</code></td>
   <td><code>/api/external/v1/people/get_assignments_count</code></td>
 </tr>
 
 <tr>
-  <td><a href="./get_binded">get_binded</a></td>
+  <td><a href="./get_binded">Get binded</a></td>
   <td><code>GET</code></td>
   <td><code>query</code></td>
   <td><code>/api/external/v1/people/get_binded</code></td>
 </tr>
 
 <tr>
-  <td><a href="./get_me">get_me</a></td>
+  <td><a href="./get_me">Get me</a></td>
   <td><code>GET</code></td>
   <td><code>query</code></td>
   <td><code>/api/external/v1/people/get_me</code></td>
 </tr>
 
 <tr>
-  <td><a href="./list">list</a></td>
+  <td><a href="./list">List</a></td>
   <td><code>GET</code></td>
   <td><code>query</code></td>
   <td><code>/api/external/v1/people/list</code></td>
 </tr>
 
 <tr>
-  <td><a href="./list_assignments">list_assignments</a></td>
+  <td><a href="./list_assignments">List assignments</a></td>
   <td><code>GET</code></td>
   <td><code>query</code></td>
   <td><code>/api/external/v1/people/list_assignments</code></td>
 </tr>
 
 <tr>
-  <td><a href="./list_possible_managers">list_possible_managers</a></td>
+  <td><a href="./list_possible_managers">List possible managers</a></td>
   <td><code>GET</code></td>
   <td><code>query</code></td>
   <td><code>/api/external/v1/people/list_possible_managers</code></td>
 </tr>
 
 <tr>
-  <td><a href="./search">search</a></td>
+  <td><a href="./search">Search</a></td>
   <td><code>GET</code></td>
   <td><code>query</code></td>
   <td><code>/api/external/v1/people/search</code></td>
 </tr>
 
 <tr>
-  <td><a href="./update">update</a></td>
+  <td><a href="./update">Update</a></td>
   <td><code>POST</code></td>
   <td><code>mutation</code></td>
   <td><code>/api/external/v1/people/update</code></td>
 </tr>
 
 <tr>
-  <td><a href="./update_picture">update_picture</a></td>
+  <td><a href="./update_picture">Update picture</a></td>
   <td><code>POST</code></td>
   <td><code>mutation</code></td>
   <td><code>/api/external/v1/people/update_picture</code></td>
 </tr>
 
 <tr>
-  <td><a href="./update_theme">update_theme</a></td>
+  <td><a href="./update_theme">Update theme</a></td>
   <td><code>POST</code></td>
   <td><code>mutation</code></td>
   <td><code>/api/external/v1/people/update_theme</code></td>

--- a/src/content/docs/help/api/people/list.mdx
+++ b/src/content/docs/help/api/people/list.mdx
@@ -1,6 +1,6 @@
 ---
-title: "list"
-description: "Generated reference for the query endpoint people/list."
+title: "People API: List"
+description: "Reference for the list query in the People API."
 ---
 
 import CurlExampleBlock from "@components/CurlExampleBlock.jsx"

--- a/src/content/docs/help/api/people/list_assignments.mdx
+++ b/src/content/docs/help/api/people/list_assignments.mdx
@@ -1,6 +1,6 @@
 ---
-title: "list_assignments"
-description: "Generated reference for the query endpoint people/list_assignments."
+title: "People API: List assignments"
+description: "Reference for the list assignments query in the People API."
 ---
 
 import CurlExampleBlock from "@components/CurlExampleBlock.jsx"

--- a/src/content/docs/help/api/people/list_possible_managers.mdx
+++ b/src/content/docs/help/api/people/list_possible_managers.mdx
@@ -1,6 +1,6 @@
 ---
-title: "list_possible_managers"
-description: "Generated reference for the query endpoint people/list_possible_managers."
+title: "People API: List possible managers"
+description: "Reference for the list possible managers query in the People API."
 ---
 
 import CurlExampleBlock from "@components/CurlExampleBlock.jsx"

--- a/src/content/docs/help/api/people/search.mdx
+++ b/src/content/docs/help/api/people/search.mdx
@@ -1,6 +1,6 @@
 ---
-title: "search"
-description: "Generated reference for the query endpoint people/search."
+title: "People API: Search"
+description: "Reference for the search query in the People API."
 ---
 
 import CurlExampleBlock from "@components/CurlExampleBlock.jsx"

--- a/src/content/docs/help/api/people/update.mdx
+++ b/src/content/docs/help/api/people/update.mdx
@@ -1,6 +1,6 @@
 ---
-title: "update"
-description: "Generated reference for the mutation endpoint people/update."
+title: "People API: Update"
+description: "Reference for the update mutation in the People API."
 ---
 
 import CurlExampleBlock from "@components/CurlExampleBlock.jsx"

--- a/src/content/docs/help/api/people/update_picture.mdx
+++ b/src/content/docs/help/api/people/update_picture.mdx
@@ -1,6 +1,6 @@
 ---
-title: "update_picture"
-description: "Generated reference for the mutation endpoint people/update_picture."
+title: "People API: Update picture"
+description: "Reference for the update picture mutation in the People API."
 ---
 
 import CurlExampleBlock from "@components/CurlExampleBlock.jsx"

--- a/src/content/docs/help/api/people/update_theme.mdx
+++ b/src/content/docs/help/api/people/update_theme.mdx
@@ -1,6 +1,6 @@
 ---
-title: "update_theme"
-description: "Generated reference for the mutation endpoint people/update_theme."
+title: "People API: Update theme"
+description: "Reference for the update theme mutation in the People API."
 ---
 
 import CurlExampleBlock from "@components/CurlExampleBlock.jsx"

--- a/src/content/docs/help/api/projects/acknowledge_check_in.mdx
+++ b/src/content/docs/help/api/projects/acknowledge_check_in.mdx
@@ -1,6 +1,6 @@
 ---
-title: "acknowledge_check_in"
-description: "Generated reference for the mutation endpoint projects/acknowledge_check_in."
+title: "Projects API: Acknowledge check-in"
+description: "Reference for the acknowledge check-in mutation in the Projects API."
 ---
 
 import CurlExampleBlock from "@components/CurlExampleBlock.jsx"

--- a/src/content/docs/help/api/projects/close.mdx
+++ b/src/content/docs/help/api/projects/close.mdx
@@ -1,6 +1,6 @@
 ---
-title: "close"
-description: "Generated reference for the mutation endpoint projects/close."
+title: "Projects API: Close"
+description: "Reference for the close mutation in the Projects API."
 ---
 
 import CurlExampleBlock from "@components/CurlExampleBlock.jsx"

--- a/src/content/docs/help/api/projects/count_children.mdx
+++ b/src/content/docs/help/api/projects/count_children.mdx
@@ -1,6 +1,6 @@
 ---
-title: "count_children"
-description: "Generated reference for the query endpoint projects/count_children."
+title: "Projects API: Count children"
+description: "Reference for the count children query in the Projects API."
 ---
 
 import CurlExampleBlock from "@components/CurlExampleBlock.jsx"

--- a/src/content/docs/help/api/projects/create.mdx
+++ b/src/content/docs/help/api/projects/create.mdx
@@ -1,6 +1,6 @@
 ---
-title: "create"
-description: "Generated reference for the mutation endpoint projects/create."
+title: "Projects API: Create"
+description: "Reference for the create mutation in the Projects API."
 ---
 
 import CurlExampleBlock from "@components/CurlExampleBlock.jsx"

--- a/src/content/docs/help/api/projects/create_check_in.mdx
+++ b/src/content/docs/help/api/projects/create_check_in.mdx
@@ -1,6 +1,6 @@
 ---
-title: "create_check_in"
-description: "Generated reference for the mutation endpoint projects/create_check_in."
+title: "Projects API: Create check-in"
+description: "Reference for the create check-in mutation in the Projects API."
 ---
 
 import CurlExampleBlock from "@components/CurlExampleBlock.jsx"

--- a/src/content/docs/help/api/projects/create_contributor.mdx
+++ b/src/content/docs/help/api/projects/create_contributor.mdx
@@ -1,6 +1,6 @@
 ---
-title: "create_contributor"
-description: "Generated reference for the mutation endpoint projects/create_contributor."
+title: "Projects API: Create contributor"
+description: "Reference for the create contributor mutation in the Projects API."
 ---
 
 import CurlExampleBlock from "@components/CurlExampleBlock.jsx"

--- a/src/content/docs/help/api/projects/create_contributors.mdx
+++ b/src/content/docs/help/api/projects/create_contributors.mdx
@@ -1,6 +1,6 @@
 ---
-title: "create_contributors"
-description: "Generated reference for the mutation endpoint projects/create_contributors."
+title: "Projects API: Create contributors"
+description: "Reference for the create contributors mutation in the Projects API."
 ---
 
 import CurlExampleBlock from "@components/CurlExampleBlock.jsx"

--- a/src/content/docs/help/api/projects/create_discussion.mdx
+++ b/src/content/docs/help/api/projects/create_discussion.mdx
@@ -1,6 +1,6 @@
 ---
-title: "create_discussion"
-description: "Generated reference for the mutation endpoint projects/create_discussion."
+title: "Projects API: Create discussion"
+description: "Reference for the create discussion mutation in the Projects API."
 ---
 
 import CurlExampleBlock from "@components/CurlExampleBlock.jsx"

--- a/src/content/docs/help/api/projects/create_key_resource.mdx
+++ b/src/content/docs/help/api/projects/create_key_resource.mdx
@@ -1,6 +1,6 @@
 ---
-title: "create_key_resource"
-description: "Generated reference for the mutation endpoint projects/create_key_resource."
+title: "Projects API: Create key resource"
+description: "Reference for the create key resource mutation in the Projects API."
 ---
 
 import CurlExampleBlock from "@components/CurlExampleBlock.jsx"

--- a/src/content/docs/help/api/projects/create_milestone.mdx
+++ b/src/content/docs/help/api/projects/create_milestone.mdx
@@ -1,6 +1,6 @@
 ---
-title: "create_milestone"
-description: "Generated reference for the mutation endpoint projects/create_milestone."
+title: "Projects API: Create milestone"
+description: "Reference for the create milestone mutation in the Projects API."
 ---
 
 import CurlExampleBlock from "@components/CurlExampleBlock.jsx"

--- a/src/content/docs/help/api/projects/create_milestone_comment.mdx
+++ b/src/content/docs/help/api/projects/create_milestone_comment.mdx
@@ -1,6 +1,6 @@
 ---
-title: "create_milestone_comment"
-description: "Generated reference for the mutation endpoint projects/create_milestone_comment."
+title: "Projects API: Create milestone comment"
+description: "Reference for the create milestone comment mutation in the Projects API."
 ---
 
 import CurlExampleBlock from "@components/CurlExampleBlock.jsx"

--- a/src/content/docs/help/api/projects/delete.mdx
+++ b/src/content/docs/help/api/projects/delete.mdx
@@ -1,6 +1,6 @@
 ---
-title: "delete"
-description: "Generated reference for the mutation endpoint projects/delete."
+title: "Projects API: Delete"
+description: "Reference for the delete mutation in the Projects API."
 ---
 
 import CurlExampleBlock from "@components/CurlExampleBlock.jsx"

--- a/src/content/docs/help/api/projects/delete_contributor.mdx
+++ b/src/content/docs/help/api/projects/delete_contributor.mdx
@@ -1,6 +1,6 @@
 ---
-title: "delete_contributor"
-description: "Generated reference for the mutation endpoint projects/delete_contributor."
+title: "Projects API: Delete contributor"
+description: "Reference for the delete contributor mutation in the Projects API."
 ---
 
 import CurlExampleBlock from "@components/CurlExampleBlock.jsx"

--- a/src/content/docs/help/api/projects/delete_key_resource.mdx
+++ b/src/content/docs/help/api/projects/delete_key_resource.mdx
@@ -1,6 +1,6 @@
 ---
-title: "delete_key_resource"
-description: "Generated reference for the mutation endpoint projects/delete_key_resource."
+title: "Projects API: Delete key resource"
+description: "Reference for the delete key resource mutation in the Projects API."
 ---
 
 import CurlExampleBlock from "@components/CurlExampleBlock.jsx"

--- a/src/content/docs/help/api/projects/delete_milestone.mdx
+++ b/src/content/docs/help/api/projects/delete_milestone.mdx
@@ -1,6 +1,6 @@
 ---
-title: "delete_milestone"
-description: "Generated reference for the mutation endpoint projects/delete_milestone."
+title: "Projects API: Delete milestone"
+description: "Reference for the delete milestone mutation in the Projects API."
 ---
 
 import CurlExampleBlock from "@components/CurlExampleBlock.jsx"

--- a/src/content/docs/help/api/projects/get.mdx
+++ b/src/content/docs/help/api/projects/get.mdx
@@ -1,6 +1,6 @@
 ---
-title: "get"
-description: "Generated reference for the query endpoint projects/get."
+title: "Projects API: Get"
+description: "Reference for the get query in the Projects API."
 ---
 
 import CurlExampleBlock from "@components/CurlExampleBlock.jsx"

--- a/src/content/docs/help/api/projects/get_check_in.mdx
+++ b/src/content/docs/help/api/projects/get_check_in.mdx
@@ -1,6 +1,6 @@
 ---
-title: "get_check_in"
-description: "Generated reference for the query endpoint projects/get_check_in."
+title: "Projects API: Get check-in"
+description: "Reference for the get check-in query in the Projects API."
 ---
 
 import CurlExampleBlock from "@components/CurlExampleBlock.jsx"

--- a/src/content/docs/help/api/projects/get_contributor.mdx
+++ b/src/content/docs/help/api/projects/get_contributor.mdx
@@ -1,6 +1,6 @@
 ---
-title: "get_contributor"
-description: "Generated reference for the query endpoint projects/get_contributor."
+title: "Projects API: Get contributor"
+description: "Reference for the get contributor query in the Projects API."
 ---
 
 import CurlExampleBlock from "@components/CurlExampleBlock.jsx"

--- a/src/content/docs/help/api/projects/get_discussion.mdx
+++ b/src/content/docs/help/api/projects/get_discussion.mdx
@@ -1,6 +1,6 @@
 ---
-title: "get_discussion"
-description: "Generated reference for the query endpoint projects/get_discussion."
+title: "Projects API: Get discussion"
+description: "Reference for the get discussion query in the Projects API."
 ---
 
 import CurlExampleBlock from "@components/CurlExampleBlock.jsx"

--- a/src/content/docs/help/api/projects/get_key_resource.mdx
+++ b/src/content/docs/help/api/projects/get_key_resource.mdx
@@ -1,6 +1,6 @@
 ---
-title: "get_key_resource"
-description: "Generated reference for the query endpoint projects/get_key_resource."
+title: "Projects API: Get key resource"
+description: "Reference for the get key resource query in the Projects API."
 ---
 
 import CurlExampleBlock from "@components/CurlExampleBlock.jsx"

--- a/src/content/docs/help/api/projects/get_milestone.mdx
+++ b/src/content/docs/help/api/projects/get_milestone.mdx
@@ -1,6 +1,6 @@
 ---
-title: "get_milestone"
-description: "Generated reference for the query endpoint projects/get_milestone."
+title: "Projects API: Get milestone"
+description: "Reference for the get milestone query in the Projects API."
 ---
 
 import CurlExampleBlock from "@components/CurlExampleBlock.jsx"

--- a/src/content/docs/help/api/projects/get_retrospective.mdx
+++ b/src/content/docs/help/api/projects/get_retrospective.mdx
@@ -1,6 +1,6 @@
 ---
-title: "get_retrospective"
-description: "Generated reference for the query endpoint projects/get_retrospective."
+title: "Projects API: Get retrospective"
+description: "Reference for the get retrospective query in the Projects API."
 ---
 
 import CurlExampleBlock from "@components/CurlExampleBlock.jsx"

--- a/src/content/docs/help/api/projects/index.mdx
+++ b/src/content/docs/help/api/projects/index.mdx
@@ -1,6 +1,6 @@
 ---
-title: API Projects
-description: Generated endpoint reference for the Projects namespace.
+title: "Projects API"
+description: "Endpoint reference for projects in the Operately API."
 ---
 
 Get, list, create and manage projects
@@ -18,378 +18,378 @@ Get, list, create and manage projects
     </thead>
     <tbody>
       <tr>
-  <td><a href="./acknowledge_check_in">acknowledge_check_in</a></td>
+  <td><a href="./acknowledge_check_in">Acknowledge check-in</a></td>
   <td><code>POST</code></td>
   <td><code>mutation</code></td>
   <td><code>/api/external/v1/projects/acknowledge_check_in</code></td>
 </tr>
 
 <tr>
-  <td><a href="./close">close</a></td>
+  <td><a href="./close">Close</a></td>
   <td><code>POST</code></td>
   <td><code>mutation</code></td>
   <td><code>/api/external/v1/projects/close</code></td>
 </tr>
 
 <tr>
-  <td><a href="./count_children">count_children</a></td>
+  <td><a href="./count_children">Count children</a></td>
   <td><code>GET</code></td>
   <td><code>query</code></td>
   <td><code>/api/external/v1/projects/count_children</code></td>
 </tr>
 
 <tr>
-  <td><a href="./create">create</a></td>
+  <td><a href="./create">Create</a></td>
   <td><code>POST</code></td>
   <td><code>mutation</code></td>
   <td><code>/api/external/v1/projects/create</code></td>
 </tr>
 
 <tr>
-  <td><a href="./create_check_in">create_check_in</a></td>
+  <td><a href="./create_check_in">Create check-in</a></td>
   <td><code>POST</code></td>
   <td><code>mutation</code></td>
   <td><code>/api/external/v1/projects/create_check_in</code></td>
 </tr>
 
 <tr>
-  <td><a href="./create_contributor">create_contributor</a></td>
+  <td><a href="./create_contributor">Create contributor</a></td>
   <td><code>POST</code></td>
   <td><code>mutation</code></td>
   <td><code>/api/external/v1/projects/create_contributor</code></td>
 </tr>
 
 <tr>
-  <td><a href="./create_contributors">create_contributors</a></td>
+  <td><a href="./create_contributors">Create contributors</a></td>
   <td><code>POST</code></td>
   <td><code>mutation</code></td>
   <td><code>/api/external/v1/projects/create_contributors</code></td>
 </tr>
 
 <tr>
-  <td><a href="./create_discussion">create_discussion</a></td>
+  <td><a href="./create_discussion">Create discussion</a></td>
   <td><code>POST</code></td>
   <td><code>mutation</code></td>
   <td><code>/api/external/v1/projects/create_discussion</code></td>
 </tr>
 
 <tr>
-  <td><a href="./create_key_resource">create_key_resource</a></td>
+  <td><a href="./create_key_resource">Create key resource</a></td>
   <td><code>POST</code></td>
   <td><code>mutation</code></td>
   <td><code>/api/external/v1/projects/create_key_resource</code></td>
 </tr>
 
 <tr>
-  <td><a href="./create_milestone">create_milestone</a></td>
+  <td><a href="./create_milestone">Create milestone</a></td>
   <td><code>POST</code></td>
   <td><code>mutation</code></td>
   <td><code>/api/external/v1/projects/create_milestone</code></td>
 </tr>
 
 <tr>
-  <td><a href="./create_milestone_comment">create_milestone_comment</a></td>
+  <td><a href="./create_milestone_comment">Create milestone comment</a></td>
   <td><code>POST</code></td>
   <td><code>mutation</code></td>
   <td><code>/api/external/v1/projects/create_milestone_comment</code></td>
 </tr>
 
 <tr>
-  <td><a href="./delete">delete</a></td>
+  <td><a href="./delete">Delete</a></td>
   <td><code>POST</code></td>
   <td><code>mutation</code></td>
   <td><code>/api/external/v1/projects/delete</code></td>
 </tr>
 
 <tr>
-  <td><a href="./delete_contributor">delete_contributor</a></td>
+  <td><a href="./delete_contributor">Delete contributor</a></td>
   <td><code>POST</code></td>
   <td><code>mutation</code></td>
   <td><code>/api/external/v1/projects/delete_contributor</code></td>
 </tr>
 
 <tr>
-  <td><a href="./delete_key_resource">delete_key_resource</a></td>
+  <td><a href="./delete_key_resource">Delete key resource</a></td>
   <td><code>POST</code></td>
   <td><code>mutation</code></td>
   <td><code>/api/external/v1/projects/delete_key_resource</code></td>
 </tr>
 
 <tr>
-  <td><a href="./delete_milestone">delete_milestone</a></td>
+  <td><a href="./delete_milestone">Delete milestone</a></td>
   <td><code>POST</code></td>
   <td><code>mutation</code></td>
   <td><code>/api/external/v1/projects/delete_milestone</code></td>
 </tr>
 
 <tr>
-  <td><a href="./get">get</a></td>
+  <td><a href="./get">Get</a></td>
   <td><code>GET</code></td>
   <td><code>query</code></td>
   <td><code>/api/external/v1/projects/get</code></td>
 </tr>
 
 <tr>
-  <td><a href="./get_check_in">get_check_in</a></td>
+  <td><a href="./get_check_in">Get check-in</a></td>
   <td><code>GET</code></td>
   <td><code>query</code></td>
   <td><code>/api/external/v1/projects/get_check_in</code></td>
 </tr>
 
 <tr>
-  <td><a href="./get_contributor">get_contributor</a></td>
+  <td><a href="./get_contributor">Get contributor</a></td>
   <td><code>GET</code></td>
   <td><code>query</code></td>
   <td><code>/api/external/v1/projects/get_contributor</code></td>
 </tr>
 
 <tr>
-  <td><a href="./get_discussion">get_discussion</a></td>
+  <td><a href="./get_discussion">Get discussion</a></td>
   <td><code>GET</code></td>
   <td><code>query</code></td>
   <td><code>/api/external/v1/projects/get_discussion</code></td>
 </tr>
 
 <tr>
-  <td><a href="./get_key_resource">get_key_resource</a></td>
+  <td><a href="./get_key_resource">Get key resource</a></td>
   <td><code>GET</code></td>
   <td><code>query</code></td>
   <td><code>/api/external/v1/projects/get_key_resource</code></td>
 </tr>
 
 <tr>
-  <td><a href="./get_milestone">get_milestone</a></td>
+  <td><a href="./get_milestone">Get milestone</a></td>
   <td><code>GET</code></td>
   <td><code>query</code></td>
   <td><code>/api/external/v1/projects/get_milestone</code></td>
 </tr>
 
 <tr>
-  <td><a href="./get_retrospective">get_retrospective</a></td>
+  <td><a href="./get_retrospective">Get retrospective</a></td>
   <td><code>GET</code></td>
   <td><code>query</code></td>
   <td><code>/api/external/v1/projects/get_retrospective</code></td>
 </tr>
 
 <tr>
-  <td><a href="./list">list</a></td>
+  <td><a href="./list">List</a></td>
   <td><code>GET</code></td>
   <td><code>query</code></td>
   <td><code>/api/external/v1/projects/list</code></td>
 </tr>
 
 <tr>
-  <td><a href="./list_check_ins">list_check_ins</a></td>
+  <td><a href="./list_check_ins">List check-ins</a></td>
   <td><code>GET</code></td>
   <td><code>query</code></td>
   <td><code>/api/external/v1/projects/list_check_ins</code></td>
 </tr>
 
 <tr>
-  <td><a href="./list_contributors">list_contributors</a></td>
+  <td><a href="./list_contributors">List contributors</a></td>
   <td><code>GET</code></td>
   <td><code>query</code></td>
   <td><code>/api/external/v1/projects/list_contributors</code></td>
 </tr>
 
 <tr>
-  <td><a href="./list_discussions">list_discussions</a></td>
+  <td><a href="./list_discussions">List discussions</a></td>
   <td><code>GET</code></td>
   <td><code>query</code></td>
   <td><code>/api/external/v1/projects/list_discussions</code></td>
 </tr>
 
 <tr>
-  <td><a href="./list_milestone_tasks">list_milestone_tasks</a></td>
+  <td><a href="./list_milestone_tasks">List milestone tasks</a></td>
   <td><code>GET</code></td>
   <td><code>query</code></td>
   <td><code>/api/external/v1/projects/list_milestone_tasks</code></td>
 </tr>
 
 <tr>
-  <td><a href="./list_milestones">list_milestones</a></td>
+  <td><a href="./list_milestones">List milestones</a></td>
   <td><code>GET</code></td>
   <td><code>query</code></td>
   <td><code>/api/external/v1/projects/list_milestones</code></td>
 </tr>
 
 <tr>
-  <td><a href="./move_to_space">move_to_space</a></td>
+  <td><a href="./move_to_space">Move to space</a></td>
   <td><code>POST</code></td>
   <td><code>mutation</code></td>
   <td><code>/api/external/v1/projects/move_to_space</code></td>
 </tr>
 
 <tr>
-  <td><a href="./pause">pause</a></td>
+  <td><a href="./pause">Pause</a></td>
   <td><code>POST</code></td>
   <td><code>mutation</code></td>
   <td><code>/api/external/v1/projects/pause</code></td>
 </tr>
 
 <tr>
-  <td><a href="./resume">resume</a></td>
+  <td><a href="./resume">Resume</a></td>
   <td><code>POST</code></td>
   <td><code>mutation</code></td>
   <td><code>/api/external/v1/projects/resume</code></td>
 </tr>
 
 <tr>
-  <td><a href="./search">search</a></td>
+  <td><a href="./search">Search</a></td>
   <td><code>GET</code></td>
   <td><code>query</code></td>
   <td><code>/api/external/v1/projects/search</code></td>
 </tr>
 
 <tr>
-  <td><a href="./search_parent_goal">search_parent_goal</a></td>
+  <td><a href="./search_parent_goal">Search parent goal</a></td>
   <td><code>GET</code></td>
   <td><code>query</code></td>
   <td><code>/api/external/v1/projects/search_parent_goal</code></td>
 </tr>
 
 <tr>
-  <td><a href="./search_potential_contributors">search_potential_contributors</a></td>
+  <td><a href="./search_potential_contributors">Search potential contributors</a></td>
   <td><code>GET</code></td>
   <td><code>query</code></td>
   <td><code>/api/external/v1/projects/search_potential_contributors</code></td>
 </tr>
 
 <tr>
-  <td><a href="./update_champion">update_champion</a></td>
+  <td><a href="./update_champion">Update champion</a></td>
   <td><code>POST</code></td>
   <td><code>mutation</code></td>
   <td><code>/api/external/v1/projects/update_champion</code></td>
 </tr>
 
 <tr>
-  <td><a href="./update_check_in">update_check_in</a></td>
+  <td><a href="./update_check_in">Update check-in</a></td>
   <td><code>POST</code></td>
   <td><code>mutation</code></td>
   <td><code>/api/external/v1/projects/update_check_in</code></td>
 </tr>
 
 <tr>
-  <td><a href="./update_contributor">update_contributor</a></td>
+  <td><a href="./update_contributor">Update contributor</a></td>
   <td><code>POST</code></td>
   <td><code>mutation</code></td>
   <td><code>/api/external/v1/projects/update_contributor</code></td>
 </tr>
 
 <tr>
-  <td><a href="./update_description">update_description</a></td>
+  <td><a href="./update_description">Update description</a></td>
   <td><code>POST</code></td>
   <td><code>mutation</code></td>
   <td><code>/api/external/v1/projects/update_description</code></td>
 </tr>
 
 <tr>
-  <td><a href="./update_discussion">update_discussion</a></td>
+  <td><a href="./update_discussion">Update discussion</a></td>
   <td><code>POST</code></td>
   <td><code>mutation</code></td>
   <td><code>/api/external/v1/projects/update_discussion</code></td>
 </tr>
 
 <tr>
-  <td><a href="./update_due_date">update_due_date</a></td>
+  <td><a href="./update_due_date">Update due date</a></td>
   <td><code>POST</code></td>
   <td><code>mutation</code></td>
   <td><code>/api/external/v1/projects/update_due_date</code></td>
 </tr>
 
 <tr>
-  <td><a href="./update_key_resource">update_key_resource</a></td>
+  <td><a href="./update_key_resource">Update key resource</a></td>
   <td><code>POST</code></td>
   <td><code>mutation</code></td>
   <td><code>/api/external/v1/projects/update_key_resource</code></td>
 </tr>
 
 <tr>
-  <td><a href="./update_milestone">update_milestone</a></td>
+  <td><a href="./update_milestone">Update milestone</a></td>
   <td><code>POST</code></td>
   <td><code>mutation</code></td>
   <td><code>/api/external/v1/projects/update_milestone</code></td>
 </tr>
 
 <tr>
-  <td><a href="./update_milestone_description">update_milestone_description</a></td>
+  <td><a href="./update_milestone_description">Update milestone description</a></td>
   <td><code>POST</code></td>
   <td><code>mutation</code></td>
   <td><code>/api/external/v1/projects/update_milestone_description</code></td>
 </tr>
 
 <tr>
-  <td><a href="./update_milestone_due_date">update_milestone_due_date</a></td>
+  <td><a href="./update_milestone_due_date">Update milestone due date</a></td>
   <td><code>POST</code></td>
   <td><code>mutation</code></td>
   <td><code>/api/external/v1/projects/update_milestone_due_date</code></td>
 </tr>
 
 <tr>
-  <td><a href="./update_milestone_kanban">update_milestone_kanban</a></td>
+  <td><a href="./update_milestone_kanban">Update milestone kanban</a></td>
   <td><code>POST</code></td>
   <td><code>mutation</code></td>
   <td><code>/api/external/v1/projects/update_milestone_kanban</code></td>
 </tr>
 
 <tr>
-  <td><a href="./update_milestone_ordering">update_milestone_ordering</a></td>
+  <td><a href="./update_milestone_ordering">Update milestone ordering</a></td>
   <td><code>POST</code></td>
   <td><code>mutation</code></td>
   <td><code>/api/external/v1/projects/update_milestone_ordering</code></td>
 </tr>
 
 <tr>
-  <td><a href="./update_milestone_title">update_milestone_title</a></td>
+  <td><a href="./update_milestone_title">Update milestone title</a></td>
   <td><code>POST</code></td>
   <td><code>mutation</code></td>
   <td><code>/api/external/v1/projects/update_milestone_title</code></td>
 </tr>
 
 <tr>
-  <td><a href="./update_name">update_name</a></td>
+  <td><a href="./update_name">Update name</a></td>
   <td><code>POST</code></td>
   <td><code>mutation</code></td>
   <td><code>/api/external/v1/projects/update_name</code></td>
 </tr>
 
 <tr>
-  <td><a href="./update_parent_goal">update_parent_goal</a></td>
+  <td><a href="./update_parent_goal">Update parent goal</a></td>
   <td><code>POST</code></td>
   <td><code>mutation</code></td>
   <td><code>/api/external/v1/projects/update_parent_goal</code></td>
 </tr>
 
 <tr>
-  <td><a href="./update_permissions">update_permissions</a></td>
+  <td><a href="./update_permissions">Update permissions</a></td>
   <td><code>POST</code></td>
   <td><code>mutation</code></td>
   <td><code>/api/external/v1/projects/update_permissions</code></td>
 </tr>
 
 <tr>
-  <td><a href="./update_retrospective">update_retrospective</a></td>
+  <td><a href="./update_retrospective">Update retrospective</a></td>
   <td><code>POST</code></td>
   <td><code>mutation</code></td>
   <td><code>/api/external/v1/projects/update_retrospective</code></td>
 </tr>
 
 <tr>
-  <td><a href="./update_reviewer">update_reviewer</a></td>
+  <td><a href="./update_reviewer">Update reviewer</a></td>
   <td><code>POST</code></td>
   <td><code>mutation</code></td>
   <td><code>/api/external/v1/projects/update_reviewer</code></td>
 </tr>
 
 <tr>
-  <td><a href="./update_start_date">update_start_date</a></td>
+  <td><a href="./update_start_date">Update start date</a></td>
   <td><code>POST</code></td>
   <td><code>mutation</code></td>
   <td><code>/api/external/v1/projects/update_start_date</code></td>
 </tr>
 
 <tr>
-  <td><a href="./update_task_statuses">update_task_statuses</a></td>
+  <td><a href="./update_task_statuses">Update task statuses</a></td>
   <td><code>POST</code></td>
   <td><code>mutation</code></td>
   <td><code>/api/external/v1/projects/update_task_statuses</code></td>

--- a/src/content/docs/help/api/projects/list.mdx
+++ b/src/content/docs/help/api/projects/list.mdx
@@ -1,6 +1,6 @@
 ---
-title: "list"
-description: "Generated reference for the query endpoint projects/list."
+title: "Projects API: List"
+description: "Reference for the list query in the Projects API."
 ---
 
 import CurlExampleBlock from "@components/CurlExampleBlock.jsx"

--- a/src/content/docs/help/api/projects/list_check_ins.mdx
+++ b/src/content/docs/help/api/projects/list_check_ins.mdx
@@ -1,6 +1,6 @@
 ---
-title: "list_check_ins"
-description: "Generated reference for the query endpoint projects/list_check_ins."
+title: "Projects API: List check-ins"
+description: "Reference for the list check-ins query in the Projects API."
 ---
 
 import CurlExampleBlock from "@components/CurlExampleBlock.jsx"

--- a/src/content/docs/help/api/projects/list_contributors.mdx
+++ b/src/content/docs/help/api/projects/list_contributors.mdx
@@ -1,6 +1,6 @@
 ---
-title: "list_contributors"
-description: "Generated reference for the query endpoint projects/list_contributors."
+title: "Projects API: List contributors"
+description: "Reference for the list contributors query in the Projects API."
 ---
 
 import CurlExampleBlock from "@components/CurlExampleBlock.jsx"

--- a/src/content/docs/help/api/projects/list_discussions.mdx
+++ b/src/content/docs/help/api/projects/list_discussions.mdx
@@ -1,6 +1,6 @@
 ---
-title: "list_discussions"
-description: "Generated reference for the query endpoint projects/list_discussions."
+title: "Projects API: List discussions"
+description: "Reference for the list discussions query in the Projects API."
 ---
 
 import CurlExampleBlock from "@components/CurlExampleBlock.jsx"

--- a/src/content/docs/help/api/projects/list_milestone_tasks.mdx
+++ b/src/content/docs/help/api/projects/list_milestone_tasks.mdx
@@ -1,6 +1,6 @@
 ---
-title: "list_milestone_tasks"
-description: "Generated reference for the query endpoint projects/list_milestone_tasks."
+title: "Projects API: List milestone tasks"
+description: "Reference for the list milestone tasks query in the Projects API."
 ---
 
 import CurlExampleBlock from "@components/CurlExampleBlock.jsx"

--- a/src/content/docs/help/api/projects/list_milestones.mdx
+++ b/src/content/docs/help/api/projects/list_milestones.mdx
@@ -1,6 +1,6 @@
 ---
-title: "list_milestones"
-description: "Generated reference for the query endpoint projects/list_milestones."
+title: "Projects API: List milestones"
+description: "Reference for the list milestones query in the Projects API."
 ---
 
 import CurlExampleBlock from "@components/CurlExampleBlock.jsx"

--- a/src/content/docs/help/api/projects/move_to_space.mdx
+++ b/src/content/docs/help/api/projects/move_to_space.mdx
@@ -1,6 +1,6 @@
 ---
-title: "move_to_space"
-description: "Generated reference for the mutation endpoint projects/move_to_space."
+title: "Projects API: Move to space"
+description: "Reference for the move to space mutation in the Projects API."
 ---
 
 import CurlExampleBlock from "@components/CurlExampleBlock.jsx"

--- a/src/content/docs/help/api/projects/pause.mdx
+++ b/src/content/docs/help/api/projects/pause.mdx
@@ -1,6 +1,6 @@
 ---
-title: "pause"
-description: "Generated reference for the mutation endpoint projects/pause."
+title: "Projects API: Pause"
+description: "Reference for the pause mutation in the Projects API."
 ---
 
 import CurlExampleBlock from "@components/CurlExampleBlock.jsx"

--- a/src/content/docs/help/api/projects/resume.mdx
+++ b/src/content/docs/help/api/projects/resume.mdx
@@ -1,6 +1,6 @@
 ---
-title: "resume"
-description: "Generated reference for the mutation endpoint projects/resume."
+title: "Projects API: Resume"
+description: "Reference for the resume mutation in the Projects API."
 ---
 
 import CurlExampleBlock from "@components/CurlExampleBlock.jsx"

--- a/src/content/docs/help/api/projects/search.mdx
+++ b/src/content/docs/help/api/projects/search.mdx
@@ -1,6 +1,6 @@
 ---
-title: "search"
-description: "Generated reference for the query endpoint projects/search."
+title: "Projects API: Search"
+description: "Reference for the search query in the Projects API."
 ---
 
 import CurlExampleBlock from "@components/CurlExampleBlock.jsx"

--- a/src/content/docs/help/api/projects/search_parent_goal.mdx
+++ b/src/content/docs/help/api/projects/search_parent_goal.mdx
@@ -1,6 +1,6 @@
 ---
-title: "search_parent_goal"
-description: "Generated reference for the query endpoint projects/search_parent_goal."
+title: "Projects API: Search parent goal"
+description: "Reference for the search parent goal query in the Projects API."
 ---
 
 import CurlExampleBlock from "@components/CurlExampleBlock.jsx"

--- a/src/content/docs/help/api/projects/search_potential_contributors.mdx
+++ b/src/content/docs/help/api/projects/search_potential_contributors.mdx
@@ -1,6 +1,6 @@
 ---
-title: "search_potential_contributors"
-description: "Generated reference for the query endpoint projects/search_potential_contributors."
+title: "Projects API: Search potential contributors"
+description: "Reference for the search potential contributors query in the Projects API."
 ---
 
 import CurlExampleBlock from "@components/CurlExampleBlock.jsx"

--- a/src/content/docs/help/api/projects/update_champion.mdx
+++ b/src/content/docs/help/api/projects/update_champion.mdx
@@ -1,6 +1,6 @@
 ---
-title: "update_champion"
-description: "Generated reference for the mutation endpoint projects/update_champion."
+title: "Projects API: Update champion"
+description: "Reference for the update champion mutation in the Projects API."
 ---
 
 import CurlExampleBlock from "@components/CurlExampleBlock.jsx"

--- a/src/content/docs/help/api/projects/update_check_in.mdx
+++ b/src/content/docs/help/api/projects/update_check_in.mdx
@@ -1,6 +1,6 @@
 ---
-title: "update_check_in"
-description: "Generated reference for the mutation endpoint projects/update_check_in."
+title: "Projects API: Update check-in"
+description: "Reference for the update check-in mutation in the Projects API."
 ---
 
 import CurlExampleBlock from "@components/CurlExampleBlock.jsx"

--- a/src/content/docs/help/api/projects/update_contributor.mdx
+++ b/src/content/docs/help/api/projects/update_contributor.mdx
@@ -1,6 +1,6 @@
 ---
-title: "update_contributor"
-description: "Generated reference for the mutation endpoint projects/update_contributor."
+title: "Projects API: Update contributor"
+description: "Reference for the update contributor mutation in the Projects API."
 ---
 
 import CurlExampleBlock from "@components/CurlExampleBlock.jsx"

--- a/src/content/docs/help/api/projects/update_description.mdx
+++ b/src/content/docs/help/api/projects/update_description.mdx
@@ -1,6 +1,6 @@
 ---
-title: "update_description"
-description: "Generated reference for the mutation endpoint projects/update_description."
+title: "Projects API: Update description"
+description: "Reference for the update description mutation in the Projects API."
 ---
 
 import CurlExampleBlock from "@components/CurlExampleBlock.jsx"

--- a/src/content/docs/help/api/projects/update_discussion.mdx
+++ b/src/content/docs/help/api/projects/update_discussion.mdx
@@ -1,6 +1,6 @@
 ---
-title: "update_discussion"
-description: "Generated reference for the mutation endpoint projects/update_discussion."
+title: "Projects API: Update discussion"
+description: "Reference for the update discussion mutation in the Projects API."
 ---
 
 import CurlExampleBlock from "@components/CurlExampleBlock.jsx"

--- a/src/content/docs/help/api/projects/update_due_date.mdx
+++ b/src/content/docs/help/api/projects/update_due_date.mdx
@@ -1,6 +1,6 @@
 ---
-title: "update_due_date"
-description: "Generated reference for the mutation endpoint projects/update_due_date."
+title: "Projects API: Update due date"
+description: "Reference for the update due date mutation in the Projects API."
 ---
 
 import CurlExampleBlock from "@components/CurlExampleBlock.jsx"

--- a/src/content/docs/help/api/projects/update_key_resource.mdx
+++ b/src/content/docs/help/api/projects/update_key_resource.mdx
@@ -1,6 +1,6 @@
 ---
-title: "update_key_resource"
-description: "Generated reference for the mutation endpoint projects/update_key_resource."
+title: "Projects API: Update key resource"
+description: "Reference for the update key resource mutation in the Projects API."
 ---
 
 import CurlExampleBlock from "@components/CurlExampleBlock.jsx"

--- a/src/content/docs/help/api/projects/update_milestone.mdx
+++ b/src/content/docs/help/api/projects/update_milestone.mdx
@@ -1,6 +1,6 @@
 ---
-title: "update_milestone"
-description: "Generated reference for the mutation endpoint projects/update_milestone."
+title: "Projects API: Update milestone"
+description: "Reference for the update milestone mutation in the Projects API."
 ---
 
 import CurlExampleBlock from "@components/CurlExampleBlock.jsx"

--- a/src/content/docs/help/api/projects/update_milestone_description.mdx
+++ b/src/content/docs/help/api/projects/update_milestone_description.mdx
@@ -1,6 +1,6 @@
 ---
-title: "update_milestone_description"
-description: "Generated reference for the mutation endpoint projects/update_milestone_description."
+title: "Projects API: Update milestone description"
+description: "Reference for the update milestone description mutation in the Projects API."
 ---
 
 import CurlExampleBlock from "@components/CurlExampleBlock.jsx"

--- a/src/content/docs/help/api/projects/update_milestone_due_date.mdx
+++ b/src/content/docs/help/api/projects/update_milestone_due_date.mdx
@@ -1,6 +1,6 @@
 ---
-title: "update_milestone_due_date"
-description: "Generated reference for the mutation endpoint projects/update_milestone_due_date."
+title: "Projects API: Update milestone due date"
+description: "Reference for the update milestone due date mutation in the Projects API."
 ---
 
 import CurlExampleBlock from "@components/CurlExampleBlock.jsx"

--- a/src/content/docs/help/api/projects/update_milestone_kanban.mdx
+++ b/src/content/docs/help/api/projects/update_milestone_kanban.mdx
@@ -1,6 +1,6 @@
 ---
-title: "update_milestone_kanban"
-description: "Generated reference for the mutation endpoint projects/update_milestone_kanban."
+title: "Projects API: Update milestone kanban"
+description: "Reference for the update milestone kanban mutation in the Projects API."
 ---
 
 import CurlExampleBlock from "@components/CurlExampleBlock.jsx"

--- a/src/content/docs/help/api/projects/update_milestone_ordering.mdx
+++ b/src/content/docs/help/api/projects/update_milestone_ordering.mdx
@@ -1,6 +1,6 @@
 ---
-title: "update_milestone_ordering"
-description: "Generated reference for the mutation endpoint projects/update_milestone_ordering."
+title: "Projects API: Update milestone ordering"
+description: "Reference for the update milestone ordering mutation in the Projects API."
 ---
 
 import CurlExampleBlock from "@components/CurlExampleBlock.jsx"

--- a/src/content/docs/help/api/projects/update_milestone_title.mdx
+++ b/src/content/docs/help/api/projects/update_milestone_title.mdx
@@ -1,6 +1,6 @@
 ---
-title: "update_milestone_title"
-description: "Generated reference for the mutation endpoint projects/update_milestone_title."
+title: "Projects API: Update milestone title"
+description: "Reference for the update milestone title mutation in the Projects API."
 ---
 
 import CurlExampleBlock from "@components/CurlExampleBlock.jsx"

--- a/src/content/docs/help/api/projects/update_name.mdx
+++ b/src/content/docs/help/api/projects/update_name.mdx
@@ -1,6 +1,6 @@
 ---
-title: "update_name"
-description: "Generated reference for the mutation endpoint projects/update_name."
+title: "Projects API: Update name"
+description: "Reference for the update name mutation in the Projects API."
 ---
 
 import CurlExampleBlock from "@components/CurlExampleBlock.jsx"

--- a/src/content/docs/help/api/projects/update_parent_goal.mdx
+++ b/src/content/docs/help/api/projects/update_parent_goal.mdx
@@ -1,6 +1,6 @@
 ---
-title: "update_parent_goal"
-description: "Generated reference for the mutation endpoint projects/update_parent_goal."
+title: "Projects API: Update parent goal"
+description: "Reference for the update parent goal mutation in the Projects API."
 ---
 
 import CurlExampleBlock from "@components/CurlExampleBlock.jsx"

--- a/src/content/docs/help/api/projects/update_permissions.mdx
+++ b/src/content/docs/help/api/projects/update_permissions.mdx
@@ -1,6 +1,6 @@
 ---
-title: "update_permissions"
-description: "Generated reference for the mutation endpoint projects/update_permissions."
+title: "Projects API: Update permissions"
+description: "Reference for the update permissions mutation in the Projects API."
 ---
 
 import CurlExampleBlock from "@components/CurlExampleBlock.jsx"

--- a/src/content/docs/help/api/projects/update_retrospective.mdx
+++ b/src/content/docs/help/api/projects/update_retrospective.mdx
@@ -1,6 +1,6 @@
 ---
-title: "update_retrospective"
-description: "Generated reference for the mutation endpoint projects/update_retrospective."
+title: "Projects API: Update retrospective"
+description: "Reference for the update retrospective mutation in the Projects API."
 ---
 
 import CurlExampleBlock from "@components/CurlExampleBlock.jsx"

--- a/src/content/docs/help/api/projects/update_reviewer.mdx
+++ b/src/content/docs/help/api/projects/update_reviewer.mdx
@@ -1,6 +1,6 @@
 ---
-title: "update_reviewer"
-description: "Generated reference for the mutation endpoint projects/update_reviewer."
+title: "Projects API: Update reviewer"
+description: "Reference for the update reviewer mutation in the Projects API."
 ---
 
 import CurlExampleBlock from "@components/CurlExampleBlock.jsx"

--- a/src/content/docs/help/api/projects/update_start_date.mdx
+++ b/src/content/docs/help/api/projects/update_start_date.mdx
@@ -1,6 +1,6 @@
 ---
-title: "update_start_date"
-description: "Generated reference for the mutation endpoint projects/update_start_date."
+title: "Projects API: Update start date"
+description: "Reference for the update start date mutation in the Projects API."
 ---
 
 import CurlExampleBlock from "@components/CurlExampleBlock.jsx"

--- a/src/content/docs/help/api/projects/update_task_statuses.mdx
+++ b/src/content/docs/help/api/projects/update_task_statuses.mdx
@@ -1,6 +1,6 @@
 ---
-title: "update_task_statuses"
-description: "Generated reference for the mutation endpoint projects/update_task_statuses."
+title: "Projects API: Update task statuses"
+description: "Reference for the update task statuses mutation in the Projects API."
 ---
 
 import CurlExampleBlock from "@components/CurlExampleBlock.jsx"

--- a/src/content/docs/help/api/reactions/create.mdx
+++ b/src/content/docs/help/api/reactions/create.mdx
@@ -1,6 +1,6 @@
 ---
-title: "create"
-description: "Generated reference for the mutation endpoint reactions/create."
+title: "Reactions API: Create"
+description: "Reference for the create mutation in the Reactions API."
 ---
 
 import CurlExampleBlock from "@components/CurlExampleBlock.jsx"

--- a/src/content/docs/help/api/reactions/delete.mdx
+++ b/src/content/docs/help/api/reactions/delete.mdx
@@ -1,6 +1,6 @@
 ---
-title: "delete"
-description: "Generated reference for the mutation endpoint reactions/delete."
+title: "Reactions API: Delete"
+description: "Reference for the delete mutation in the Reactions API."
 ---
 
 import CurlExampleBlock from "@components/CurlExampleBlock.jsx"

--- a/src/content/docs/help/api/reactions/index.mdx
+++ b/src/content/docs/help/api/reactions/index.mdx
@@ -1,6 +1,6 @@
 ---
-title: API Reactions
-description: Generated endpoint reference for the Reactions namespace.
+title: "Reactions API"
+description: "Endpoint reference for reactions in the Operately API."
 ---
 
 Add or remove emoji reactions to content
@@ -18,14 +18,14 @@ Add or remove emoji reactions to content
     </thead>
     <tbody>
       <tr>
-  <td><a href="./create">create</a></td>
+  <td><a href="./create">Create</a></td>
   <td><code>POST</code></td>
   <td><code>mutation</code></td>
   <td><code>/api/external/v1/reactions/create</code></td>
 </tr>
 
 <tr>
-  <td><a href="./delete">delete</a></td>
+  <td><a href="./delete">Delete</a></td>
   <td><code>POST</code></td>
   <td><code>mutation</code></td>
   <td><code>/api/external/v1/reactions/delete</code></td>

--- a/src/content/docs/help/api/resource_hubs/copy_folder.mdx
+++ b/src/content/docs/help/api/resource_hubs/copy_folder.mdx
@@ -1,6 +1,6 @@
 ---
-title: "copy_folder"
-description: "Generated reference for the mutation endpoint resource_hubs/copy_folder."
+title: "Resource Hubs API: Copy folder"
+description: "Reference for the copy folder mutation in the Resource Hubs API."
 ---
 
 import CurlExampleBlock from "@components/CurlExampleBlock.jsx"

--- a/src/content/docs/help/api/resource_hubs/create.mdx
+++ b/src/content/docs/help/api/resource_hubs/create.mdx
@@ -1,6 +1,6 @@
 ---
-title: "create"
-description: "Generated reference for the mutation endpoint resource_hubs/create."
+title: "Resource Hubs API: Create"
+description: "Reference for the create mutation in the Resource Hubs API."
 ---
 
 import CurlExampleBlock from "@components/CurlExampleBlock.jsx"

--- a/src/content/docs/help/api/resource_hubs/create_folder.mdx
+++ b/src/content/docs/help/api/resource_hubs/create_folder.mdx
@@ -1,6 +1,6 @@
 ---
-title: "create_folder"
-description: "Generated reference for the mutation endpoint resource_hubs/create_folder."
+title: "Resource Hubs API: Create folder"
+description: "Reference for the create folder mutation in the Resource Hubs API."
 ---
 
 import CurlExampleBlock from "@components/CurlExampleBlock.jsx"

--- a/src/content/docs/help/api/resource_hubs/delete_folder.mdx
+++ b/src/content/docs/help/api/resource_hubs/delete_folder.mdx
@@ -1,6 +1,6 @@
 ---
-title: "delete_folder"
-description: "Generated reference for the mutation endpoint resource_hubs/delete_folder."
+title: "Resource Hubs API: Delete folder"
+description: "Reference for the delete folder mutation in the Resource Hubs API."
 ---
 
 import CurlExampleBlock from "@components/CurlExampleBlock.jsx"

--- a/src/content/docs/help/api/resource_hubs/get.mdx
+++ b/src/content/docs/help/api/resource_hubs/get.mdx
@@ -1,6 +1,6 @@
 ---
-title: "get"
-description: "Generated reference for the query endpoint resource_hubs/get."
+title: "Resource Hubs API: Get"
+description: "Reference for the get query in the Resource Hubs API."
 ---
 
 import CurlExampleBlock from "@components/CurlExampleBlock.jsx"

--- a/src/content/docs/help/api/resource_hubs/get_folder.mdx
+++ b/src/content/docs/help/api/resource_hubs/get_folder.mdx
@@ -1,6 +1,6 @@
 ---
-title: "get_folder"
-description: "Generated reference for the query endpoint resource_hubs/get_folder."
+title: "Resource Hubs API: Get folder"
+description: "Reference for the get folder query in the Resource Hubs API."
 ---
 
 import CurlExampleBlock from "@components/CurlExampleBlock.jsx"

--- a/src/content/docs/help/api/resource_hubs/index.mdx
+++ b/src/content/docs/help/api/resource_hubs/index.mdx
@@ -1,6 +1,6 @@
 ---
-title: API Resource hubs
-description: Generated endpoint reference for the Resource hubs namespace.
+title: "Resource Hubs API"
+description: "Endpoint reference for resource hubs in the Operately API."
 ---
 
 Get and create resource hubs
@@ -18,63 +18,63 @@ Get and create resource hubs
     </thead>
     <tbody>
       <tr>
-  <td><a href="./copy_folder">copy_folder</a></td>
+  <td><a href="./copy_folder">Copy folder</a></td>
   <td><code>POST</code></td>
   <td><code>mutation</code></td>
   <td><code>/api/external/v1/resource_hubs/copy_folder</code></td>
 </tr>
 
 <tr>
-  <td><a href="./create">create</a></td>
+  <td><a href="./create">Create</a></td>
   <td><code>POST</code></td>
   <td><code>mutation</code></td>
   <td><code>/api/external/v1/resource_hubs/create</code></td>
 </tr>
 
 <tr>
-  <td><a href="./create_folder">create_folder</a></td>
+  <td><a href="./create_folder">Create folder</a></td>
   <td><code>POST</code></td>
   <td><code>mutation</code></td>
   <td><code>/api/external/v1/resource_hubs/create_folder</code></td>
 </tr>
 
 <tr>
-  <td><a href="./delete_folder">delete_folder</a></td>
+  <td><a href="./delete_folder">Delete folder</a></td>
   <td><code>POST</code></td>
   <td><code>mutation</code></td>
   <td><code>/api/external/v1/resource_hubs/delete_folder</code></td>
 </tr>
 
 <tr>
-  <td><a href="./get">get</a></td>
+  <td><a href="./get">Get</a></td>
   <td><code>GET</code></td>
   <td><code>query</code></td>
   <td><code>/api/external/v1/resource_hubs/get</code></td>
 </tr>
 
 <tr>
-  <td><a href="./get_folder">get_folder</a></td>
+  <td><a href="./get_folder">Get folder</a></td>
   <td><code>GET</code></td>
   <td><code>query</code></td>
   <td><code>/api/external/v1/resource_hubs/get_folder</code></td>
 </tr>
 
 <tr>
-  <td><a href="./list_nodes">list_nodes</a></td>
+  <td><a href="./list_nodes">List nodes</a></td>
   <td><code>GET</code></td>
   <td><code>query</code></td>
   <td><code>/api/external/v1/resource_hubs/list_nodes</code></td>
 </tr>
 
 <tr>
-  <td><a href="./rename_folder">rename_folder</a></td>
+  <td><a href="./rename_folder">Rename folder</a></td>
   <td><code>POST</code></td>
   <td><code>mutation</code></td>
   <td><code>/api/external/v1/resource_hubs/rename_folder</code></td>
 </tr>
 
 <tr>
-  <td><a href="./update_parent_folder">update_parent_folder</a></td>
+  <td><a href="./update_parent_folder">Update parent folder</a></td>
   <td><code>POST</code></td>
   <td><code>mutation</code></td>
   <td><code>/api/external/v1/resource_hubs/update_parent_folder</code></td>

--- a/src/content/docs/help/api/resource_hubs/list_nodes.mdx
+++ b/src/content/docs/help/api/resource_hubs/list_nodes.mdx
@@ -1,6 +1,6 @@
 ---
-title: "list_nodes"
-description: "Generated reference for the query endpoint resource_hubs/list_nodes."
+title: "Resource Hubs API: List nodes"
+description: "Reference for the list nodes query in the Resource Hubs API."
 ---
 
 import CurlExampleBlock from "@components/CurlExampleBlock.jsx"

--- a/src/content/docs/help/api/resource_hubs/rename_folder.mdx
+++ b/src/content/docs/help/api/resource_hubs/rename_folder.mdx
@@ -1,6 +1,6 @@
 ---
-title: "rename_folder"
-description: "Generated reference for the mutation endpoint resource_hubs/rename_folder."
+title: "Resource Hubs API: Rename folder"
+description: "Reference for the rename folder mutation in the Resource Hubs API."
 ---
 
 import CurlExampleBlock from "@components/CurlExampleBlock.jsx"

--- a/src/content/docs/help/api/resource_hubs/update_parent_folder.mdx
+++ b/src/content/docs/help/api/resource_hubs/update_parent_folder.mdx
@@ -1,6 +1,6 @@
 ---
-title: "update_parent_folder"
-description: "Generated reference for the mutation endpoint resource_hubs/update_parent_folder."
+title: "Resource Hubs API: Update parent folder"
+description: "Reference for the update parent folder mutation in the Resource Hubs API."
 ---
 
 import CurlExampleBlock from "@components/CurlExampleBlock.jsx"

--- a/src/content/docs/help/api/spaces/add_members.mdx
+++ b/src/content/docs/help/api/spaces/add_members.mdx
@@ -1,6 +1,6 @@
 ---
-title: "add_members"
-description: "Generated reference for the mutation endpoint spaces/add_members."
+title: "Spaces API: Add members"
+description: "Reference for the add members mutation in the Spaces API."
 ---
 
 import CurlExampleBlock from "@components/CurlExampleBlock.jsx"

--- a/src/content/docs/help/api/spaces/archive_discussion.mdx
+++ b/src/content/docs/help/api/spaces/archive_discussion.mdx
@@ -1,6 +1,6 @@
 ---
-title: "archive_discussion"
-description: "Generated reference for the mutation endpoint spaces/archive_discussion."
+title: "Spaces API: Archive discussion"
+description: "Reference for the archive discussion mutation in the Spaces API."
 ---
 
 import CurlExampleBlock from "@components/CurlExampleBlock.jsx"

--- a/src/content/docs/help/api/spaces/count_by_access_level.mdx
+++ b/src/content/docs/help/api/spaces/count_by_access_level.mdx
@@ -1,6 +1,6 @@
 ---
-title: "count_by_access_level"
-description: "Generated reference for the query endpoint spaces/count_by_access_level."
+title: "Spaces API: Count by access level"
+description: "Reference for the count by access level query in the Spaces API."
 ---
 
 import CurlExampleBlock from "@components/CurlExampleBlock.jsx"

--- a/src/content/docs/help/api/spaces/create.mdx
+++ b/src/content/docs/help/api/spaces/create.mdx
@@ -1,6 +1,6 @@
 ---
-title: "create"
-description: "Generated reference for the mutation endpoint spaces/create."
+title: "Spaces API: Create"
+description: "Reference for the create mutation in the Spaces API."
 ---
 
 import CurlExampleBlock from "@components/CurlExampleBlock.jsx"

--- a/src/content/docs/help/api/spaces/create_discussion.mdx
+++ b/src/content/docs/help/api/spaces/create_discussion.mdx
@@ -1,6 +1,6 @@
 ---
-title: "create_discussion"
-description: "Generated reference for the mutation endpoint spaces/create_discussion."
+title: "Spaces API: Create discussion"
+description: "Reference for the create discussion mutation in the Spaces API."
 ---
 
 import CurlExampleBlock from "@components/CurlExampleBlock.jsx"

--- a/src/content/docs/help/api/spaces/delete.mdx
+++ b/src/content/docs/help/api/spaces/delete.mdx
@@ -1,6 +1,6 @@
 ---
-title: "delete"
-description: "Generated reference for the mutation endpoint spaces/delete."
+title: "Spaces API: Delete"
+description: "Reference for the delete mutation in the Spaces API."
 ---
 
 import CurlExampleBlock from "@components/CurlExampleBlock.jsx"

--- a/src/content/docs/help/api/spaces/delete_member.mdx
+++ b/src/content/docs/help/api/spaces/delete_member.mdx
@@ -1,6 +1,6 @@
 ---
-title: "delete_member"
-description: "Generated reference for the mutation endpoint spaces/delete_member."
+title: "Spaces API: Delete member"
+description: "Reference for the delete member mutation in the Spaces API."
 ---
 
 import CurlExampleBlock from "@components/CurlExampleBlock.jsx"

--- a/src/content/docs/help/api/spaces/get.mdx
+++ b/src/content/docs/help/api/spaces/get.mdx
@@ -1,6 +1,6 @@
 ---
-title: "get"
-description: "Generated reference for the query endpoint spaces/get."
+title: "Spaces API: Get"
+description: "Reference for the get query in the Spaces API."
 ---
 
 import CurlExampleBlock from "@components/CurlExampleBlock.jsx"

--- a/src/content/docs/help/api/spaces/get_discussion.mdx
+++ b/src/content/docs/help/api/spaces/get_discussion.mdx
@@ -1,6 +1,6 @@
 ---
-title: "get_discussion"
-description: "Generated reference for the query endpoint spaces/get_discussion."
+title: "Spaces API: Get discussion"
+description: "Reference for the get discussion query in the Spaces API."
 ---
 
 import CurlExampleBlock from "@components/CurlExampleBlock.jsx"

--- a/src/content/docs/help/api/spaces/index.mdx
+++ b/src/content/docs/help/api/spaces/index.mdx
@@ -1,6 +1,6 @@
 ---
-title: API Spaces
-description: Generated endpoint reference for the Spaces namespace.
+title: "Spaces API"
+description: "Endpoint reference for spaces in the Operately API."
 ---
 
 Get, list, create and manage spaces
@@ -18,168 +18,168 @@ Get, list, create and manage spaces
     </thead>
     <tbody>
       <tr>
-  <td><a href="./add_members">add_members</a></td>
+  <td><a href="./add_members">Add members</a></td>
   <td><code>POST</code></td>
   <td><code>mutation</code></td>
   <td><code>/api/external/v1/spaces/add_members</code></td>
 </tr>
 
 <tr>
-  <td><a href="./archive_discussion">archive_discussion</a></td>
+  <td><a href="./archive_discussion">Archive discussion</a></td>
   <td><code>POST</code></td>
   <td><code>mutation</code></td>
   <td><code>/api/external/v1/spaces/archive_discussion</code></td>
 </tr>
 
 <tr>
-  <td><a href="./count_by_access_level">count_by_access_level</a></td>
+  <td><a href="./count_by_access_level">Count by access level</a></td>
   <td><code>GET</code></td>
   <td><code>query</code></td>
   <td><code>/api/external/v1/spaces/count_by_access_level</code></td>
 </tr>
 
 <tr>
-  <td><a href="./create">create</a></td>
+  <td><a href="./create">Create</a></td>
   <td><code>POST</code></td>
   <td><code>mutation</code></td>
   <td><code>/api/external/v1/spaces/create</code></td>
 </tr>
 
 <tr>
-  <td><a href="./create_discussion">create_discussion</a></td>
+  <td><a href="./create_discussion">Create discussion</a></td>
   <td><code>POST</code></td>
   <td><code>mutation</code></td>
   <td><code>/api/external/v1/spaces/create_discussion</code></td>
 </tr>
 
 <tr>
-  <td><a href="./delete">delete</a></td>
+  <td><a href="./delete">Delete</a></td>
   <td><code>POST</code></td>
   <td><code>mutation</code></td>
   <td><code>/api/external/v1/spaces/delete</code></td>
 </tr>
 
 <tr>
-  <td><a href="./delete_member">delete_member</a></td>
+  <td><a href="./delete_member">Delete member</a></td>
   <td><code>POST</code></td>
   <td><code>mutation</code></td>
   <td><code>/api/external/v1/spaces/delete_member</code></td>
 </tr>
 
 <tr>
-  <td><a href="./get">get</a></td>
+  <td><a href="./get">Get</a></td>
   <td><code>GET</code></td>
   <td><code>query</code></td>
   <td><code>/api/external/v1/spaces/get</code></td>
 </tr>
 
 <tr>
-  <td><a href="./get_discussion">get_discussion</a></td>
+  <td><a href="./get_discussion">Get discussion</a></td>
   <td><code>GET</code></td>
   <td><code>query</code></td>
   <td><code>/api/external/v1/spaces/get_discussion</code></td>
 </tr>
 
 <tr>
-  <td><a href="./join">join</a></td>
+  <td><a href="./join">Join</a></td>
   <td><code>POST</code></td>
   <td><code>mutation</code></td>
   <td><code>/api/external/v1/spaces/join</code></td>
 </tr>
 
 <tr>
-  <td><a href="./list">list</a></td>
+  <td><a href="./list">List</a></td>
   <td><code>GET</code></td>
   <td><code>query</code></td>
   <td><code>/api/external/v1/spaces/list</code></td>
 </tr>
 
 <tr>
-  <td><a href="./list_discussions">list_discussions</a></td>
+  <td><a href="./list_discussions">List discussions</a></td>
   <td><code>GET</code></td>
   <td><code>query</code></td>
   <td><code>/api/external/v1/spaces/list_discussions</code></td>
 </tr>
 
 <tr>
-  <td><a href="./list_members">list_members</a></td>
+  <td><a href="./list_members">List members</a></td>
   <td><code>GET</code></td>
   <td><code>query</code></td>
   <td><code>/api/external/v1/spaces/list_members</code></td>
 </tr>
 
 <tr>
-  <td><a href="./list_tasks">list_tasks</a></td>
+  <td><a href="./list_tasks">List tasks</a></td>
   <td><code>GET</code></td>
   <td><code>query</code></td>
   <td><code>/api/external/v1/spaces/list_tasks</code></td>
 </tr>
 
 <tr>
-  <td><a href="./list_tools">list_tools</a></td>
+  <td><a href="./list_tools">List tools</a></td>
   <td><code>GET</code></td>
   <td><code>query</code></td>
   <td><code>/api/external/v1/spaces/list_tools</code></td>
 </tr>
 
 <tr>
-  <td><a href="./publish_discussion">publish_discussion</a></td>
+  <td><a href="./publish_discussion">Publish discussion</a></td>
   <td><code>POST</code></td>
   <td><code>mutation</code></td>
   <td><code>/api/external/v1/spaces/publish_discussion</code></td>
 </tr>
 
 <tr>
-  <td><a href="./search">search</a></td>
+  <td><a href="./search">Search</a></td>
   <td><code>GET</code></td>
   <td><code>query</code></td>
   <td><code>/api/external/v1/spaces/search</code></td>
 </tr>
 
 <tr>
-  <td><a href="./search_potential_members">search_potential_members</a></td>
+  <td><a href="./search_potential_members">Search potential members</a></td>
   <td><code>GET</code></td>
   <td><code>query</code></td>
   <td><code>/api/external/v1/spaces/search_potential_members</code></td>
 </tr>
 
 <tr>
-  <td><a href="./update">update</a></td>
+  <td><a href="./update">Update</a></td>
   <td><code>POST</code></td>
   <td><code>mutation</code></td>
   <td><code>/api/external/v1/spaces/update</code></td>
 </tr>
 
 <tr>
-  <td><a href="./update_discussion">update_discussion</a></td>
+  <td><a href="./update_discussion">Update discussion</a></td>
   <td><code>POST</code></td>
   <td><code>mutation</code></td>
   <td><code>/api/external/v1/spaces/update_discussion</code></td>
 </tr>
 
 <tr>
-  <td><a href="./update_members_permissions">update_members_permissions</a></td>
+  <td><a href="./update_members_permissions">Update members permissions</a></td>
   <td><code>POST</code></td>
   <td><code>mutation</code></td>
   <td><code>/api/external/v1/spaces/update_members_permissions</code></td>
 </tr>
 
 <tr>
-  <td><a href="./update_permissions">update_permissions</a></td>
+  <td><a href="./update_permissions">Update permissions</a></td>
   <td><code>POST</code></td>
   <td><code>mutation</code></td>
   <td><code>/api/external/v1/spaces/update_permissions</code></td>
 </tr>
 
 <tr>
-  <td><a href="./update_task_statuses">update_task_statuses</a></td>
+  <td><a href="./update_task_statuses">Update task statuses</a></td>
   <td><code>POST</code></td>
   <td><code>mutation</code></td>
   <td><code>/api/external/v1/spaces/update_task_statuses</code></td>
 </tr>
 
 <tr>
-  <td><a href="./update_tools">update_tools</a></td>
+  <td><a href="./update_tools">Update tools</a></td>
   <td><code>POST</code></td>
   <td><code>mutation</code></td>
   <td><code>/api/external/v1/spaces/update_tools</code></td>

--- a/src/content/docs/help/api/spaces/join.mdx
+++ b/src/content/docs/help/api/spaces/join.mdx
@@ -1,6 +1,6 @@
 ---
-title: "join"
-description: "Generated reference for the mutation endpoint spaces/join."
+title: "Spaces API: Join"
+description: "Reference for the join mutation in the Spaces API."
 ---
 
 import CurlExampleBlock from "@components/CurlExampleBlock.jsx"

--- a/src/content/docs/help/api/spaces/list.mdx
+++ b/src/content/docs/help/api/spaces/list.mdx
@@ -1,6 +1,6 @@
 ---
-title: "list"
-description: "Generated reference for the query endpoint spaces/list."
+title: "Spaces API: List"
+description: "Reference for the list query in the Spaces API."
 ---
 
 import CurlExampleBlock from "@components/CurlExampleBlock.jsx"

--- a/src/content/docs/help/api/spaces/list_discussions.mdx
+++ b/src/content/docs/help/api/spaces/list_discussions.mdx
@@ -1,6 +1,6 @@
 ---
-title: "list_discussions"
-description: "Generated reference for the query endpoint spaces/list_discussions."
+title: "Spaces API: List discussions"
+description: "Reference for the list discussions query in the Spaces API."
 ---
 
 import CurlExampleBlock from "@components/CurlExampleBlock.jsx"

--- a/src/content/docs/help/api/spaces/list_members.mdx
+++ b/src/content/docs/help/api/spaces/list_members.mdx
@@ -1,6 +1,6 @@
 ---
-title: "list_members"
-description: "Generated reference for the query endpoint spaces/list_members."
+title: "Spaces API: List members"
+description: "Reference for the list members query in the Spaces API."
 ---
 
 import CurlExampleBlock from "@components/CurlExampleBlock.jsx"

--- a/src/content/docs/help/api/spaces/list_tasks.mdx
+++ b/src/content/docs/help/api/spaces/list_tasks.mdx
@@ -1,6 +1,6 @@
 ---
-title: "list_tasks"
-description: "Generated reference for the query endpoint spaces/list_tasks."
+title: "Spaces API: List tasks"
+description: "Reference for the list tasks query in the Spaces API."
 ---
 
 import CurlExampleBlock from "@components/CurlExampleBlock.jsx"

--- a/src/content/docs/help/api/spaces/list_tools.mdx
+++ b/src/content/docs/help/api/spaces/list_tools.mdx
@@ -1,6 +1,6 @@
 ---
-title: "list_tools"
-description: "Generated reference for the query endpoint spaces/list_tools."
+title: "Spaces API: List tools"
+description: "Reference for the list tools query in the Spaces API."
 ---
 
 import CurlExampleBlock from "@components/CurlExampleBlock.jsx"

--- a/src/content/docs/help/api/spaces/publish_discussion.mdx
+++ b/src/content/docs/help/api/spaces/publish_discussion.mdx
@@ -1,6 +1,6 @@
 ---
-title: "publish_discussion"
-description: "Generated reference for the mutation endpoint spaces/publish_discussion."
+title: "Spaces API: Publish discussion"
+description: "Reference for the publish discussion mutation in the Spaces API."
 ---
 
 import CurlExampleBlock from "@components/CurlExampleBlock.jsx"

--- a/src/content/docs/help/api/spaces/search.mdx
+++ b/src/content/docs/help/api/spaces/search.mdx
@@ -1,6 +1,6 @@
 ---
-title: "search"
-description: "Generated reference for the query endpoint spaces/search."
+title: "Spaces API: Search"
+description: "Reference for the search query in the Spaces API."
 ---
 
 import CurlExampleBlock from "@components/CurlExampleBlock.jsx"

--- a/src/content/docs/help/api/spaces/search_potential_members.mdx
+++ b/src/content/docs/help/api/spaces/search_potential_members.mdx
@@ -1,6 +1,6 @@
 ---
-title: "search_potential_members"
-description: "Generated reference for the query endpoint spaces/search_potential_members."
+title: "Spaces API: Search potential members"
+description: "Reference for the search potential members query in the Spaces API."
 ---
 
 import CurlExampleBlock from "@components/CurlExampleBlock.jsx"

--- a/src/content/docs/help/api/spaces/update.mdx
+++ b/src/content/docs/help/api/spaces/update.mdx
@@ -1,6 +1,6 @@
 ---
-title: "update"
-description: "Generated reference for the mutation endpoint spaces/update."
+title: "Spaces API: Update"
+description: "Reference for the update mutation in the Spaces API."
 ---
 
 import CurlExampleBlock from "@components/CurlExampleBlock.jsx"

--- a/src/content/docs/help/api/spaces/update_discussion.mdx
+++ b/src/content/docs/help/api/spaces/update_discussion.mdx
@@ -1,6 +1,6 @@
 ---
-title: "update_discussion"
-description: "Generated reference for the mutation endpoint spaces/update_discussion."
+title: "Spaces API: Update discussion"
+description: "Reference for the update discussion mutation in the Spaces API."
 ---
 
 import CurlExampleBlock from "@components/CurlExampleBlock.jsx"

--- a/src/content/docs/help/api/spaces/update_members_permissions.mdx
+++ b/src/content/docs/help/api/spaces/update_members_permissions.mdx
@@ -1,6 +1,6 @@
 ---
-title: "update_members_permissions"
-description: "Generated reference for the mutation endpoint spaces/update_members_permissions."
+title: "Spaces API: Update members permissions"
+description: "Reference for the update members permissions mutation in the Spaces API."
 ---
 
 import CurlExampleBlock from "@components/CurlExampleBlock.jsx"

--- a/src/content/docs/help/api/spaces/update_permissions.mdx
+++ b/src/content/docs/help/api/spaces/update_permissions.mdx
@@ -1,6 +1,6 @@
 ---
-title: "update_permissions"
-description: "Generated reference for the mutation endpoint spaces/update_permissions."
+title: "Spaces API: Update permissions"
+description: "Reference for the update permissions mutation in the Spaces API."
 ---
 
 import CurlExampleBlock from "@components/CurlExampleBlock.jsx"

--- a/src/content/docs/help/api/spaces/update_task_statuses.mdx
+++ b/src/content/docs/help/api/spaces/update_task_statuses.mdx
@@ -1,6 +1,6 @@
 ---
-title: "update_task_statuses"
-description: "Generated reference for the mutation endpoint spaces/update_task_statuses."
+title: "Spaces API: Update task statuses"
+description: "Reference for the update task statuses mutation in the Spaces API."
 ---
 
 import CurlExampleBlock from "@components/CurlExampleBlock.jsx"

--- a/src/content/docs/help/api/spaces/update_tools.mdx
+++ b/src/content/docs/help/api/spaces/update_tools.mdx
@@ -1,6 +1,6 @@
 ---
-title: "update_tools"
-description: "Generated reference for the mutation endpoint spaces/update_tools."
+title: "Spaces API: Update tools"
+description: "Reference for the update tools mutation in the Spaces API."
 ---
 
 import CurlExampleBlock from "@components/CurlExampleBlock.jsx"

--- a/src/content/docs/help/api/tasks/create.mdx
+++ b/src/content/docs/help/api/tasks/create.mdx
@@ -1,6 +1,6 @@
 ---
-title: "create"
-description: "Generated reference for the mutation endpoint tasks/create."
+title: "Tasks API: Create"
+description: "Reference for the create mutation in the Tasks API."
 ---
 
 import CurlExampleBlock from "@components/CurlExampleBlock.jsx"

--- a/src/content/docs/help/api/tasks/delete.mdx
+++ b/src/content/docs/help/api/tasks/delete.mdx
@@ -1,6 +1,6 @@
 ---
-title: "delete"
-description: "Generated reference for the mutation endpoint tasks/delete."
+title: "Tasks API: Delete"
+description: "Reference for the delete mutation in the Tasks API."
 ---
 
 import CurlExampleBlock from "@components/CurlExampleBlock.jsx"

--- a/src/content/docs/help/api/tasks/get.mdx
+++ b/src/content/docs/help/api/tasks/get.mdx
@@ -1,6 +1,6 @@
 ---
-title: "get"
-description: "Generated reference for the query endpoint tasks/get."
+title: "Tasks API: Get"
+description: "Reference for the get query in the Tasks API."
 ---
 
 import CurlExampleBlock from "@components/CurlExampleBlock.jsx"

--- a/src/content/docs/help/api/tasks/index.mdx
+++ b/src/content/docs/help/api/tasks/index.mdx
@@ -1,6 +1,6 @@
 ---
-title: API Tasks
-description: Generated endpoint reference for the Tasks namespace.
+title: "Tasks API"
+description: "Endpoint reference for tasks in the Operately API."
 ---
 
 Get, list, create and manage tasks across projects and spaces
@@ -18,91 +18,91 @@ Get, list, create and manage tasks across projects and spaces
     </thead>
     <tbody>
       <tr>
-  <td><a href="./create">create</a></td>
+  <td><a href="./create">Create</a></td>
   <td><code>POST</code></td>
   <td><code>mutation</code></td>
   <td><code>/api/external/v1/tasks/create</code></td>
 </tr>
 
 <tr>
-  <td><a href="./delete">delete</a></td>
+  <td><a href="./delete">Delete</a></td>
   <td><code>POST</code></td>
   <td><code>mutation</code></td>
   <td><code>/api/external/v1/tasks/delete</code></td>
 </tr>
 
 <tr>
-  <td><a href="./get">get</a></td>
+  <td><a href="./get">Get</a></td>
   <td><code>GET</code></td>
   <td><code>query</code></td>
   <td><code>/api/external/v1/tasks/get</code></td>
 </tr>
 
 <tr>
-  <td><a href="./list">list</a></td>
+  <td><a href="./list">List</a></td>
   <td><code>GET</code></td>
   <td><code>query</code></td>
   <td><code>/api/external/v1/tasks/list</code></td>
 </tr>
 
 <tr>
-  <td><a href="./list_potential_assignees">list_potential_assignees</a></td>
+  <td><a href="./list_potential_assignees">List potential assignees</a></td>
   <td><code>GET</code></td>
   <td><code>query</code></td>
   <td><code>/api/external/v1/tasks/list_potential_assignees</code></td>
 </tr>
 
 <tr>
-  <td><a href="./move">move</a></td>
+  <td><a href="./move">Move</a></td>
   <td><code>POST</code></td>
   <td><code>mutation</code></td>
   <td><code>/api/external/v1/tasks/move</code></td>
 </tr>
 
 <tr>
-  <td><a href="./update_assignee">update_assignee</a></td>
+  <td><a href="./update_assignee">Update assignee</a></td>
   <td><code>POST</code></td>
   <td><code>mutation</code></td>
   <td><code>/api/external/v1/tasks/update_assignee</code></td>
 </tr>
 
 <tr>
-  <td><a href="./update_description">update_description</a></td>
+  <td><a href="./update_description">Update description</a></td>
   <td><code>POST</code></td>
   <td><code>mutation</code></td>
   <td><code>/api/external/v1/tasks/update_description</code></td>
 </tr>
 
 <tr>
-  <td><a href="./update_due_date">update_due_date</a></td>
+  <td><a href="./update_due_date">Update due date</a></td>
   <td><code>POST</code></td>
   <td><code>mutation</code></td>
   <td><code>/api/external/v1/tasks/update_due_date</code></td>
 </tr>
 
 <tr>
-  <td><a href="./update_milestone">update_milestone</a></td>
+  <td><a href="./update_milestone">Update milestone</a></td>
   <td><code>POST</code></td>
   <td><code>mutation</code></td>
   <td><code>/api/external/v1/tasks/update_milestone</code></td>
 </tr>
 
 <tr>
-  <td><a href="./update_milestone_and_ordering">update_milestone_and_ordering</a></td>
+  <td><a href="./update_milestone_and_ordering">Update milestone and ordering</a></td>
   <td><code>POST</code></td>
   <td><code>mutation</code></td>
   <td><code>/api/external/v1/tasks/update_milestone_and_ordering</code></td>
 </tr>
 
 <tr>
-  <td><a href="./update_name">update_name</a></td>
+  <td><a href="./update_name">Update name</a></td>
   <td><code>POST</code></td>
   <td><code>mutation</code></td>
   <td><code>/api/external/v1/tasks/update_name</code></td>
 </tr>
 
 <tr>
-  <td><a href="./update_status">update_status</a></td>
+  <td><a href="./update_status">Update status</a></td>
   <td><code>POST</code></td>
   <td><code>mutation</code></td>
   <td><code>/api/external/v1/tasks/update_status</code></td>

--- a/src/content/docs/help/api/tasks/list.mdx
+++ b/src/content/docs/help/api/tasks/list.mdx
@@ -1,6 +1,6 @@
 ---
-title: "list"
-description: "Generated reference for the query endpoint tasks/list."
+title: "Tasks API: List"
+description: "Reference for the list query in the Tasks API."
 ---
 
 import CurlExampleBlock from "@components/CurlExampleBlock.jsx"

--- a/src/content/docs/help/api/tasks/list_potential_assignees.mdx
+++ b/src/content/docs/help/api/tasks/list_potential_assignees.mdx
@@ -1,6 +1,6 @@
 ---
-title: "list_potential_assignees"
-description: "Generated reference for the query endpoint tasks/list_potential_assignees."
+title: "Tasks API: List potential assignees"
+description: "Reference for the list potential assignees query in the Tasks API."
 ---
 
 import CurlExampleBlock from "@components/CurlExampleBlock.jsx"

--- a/src/content/docs/help/api/tasks/move.mdx
+++ b/src/content/docs/help/api/tasks/move.mdx
@@ -1,6 +1,6 @@
 ---
-title: "move"
-description: "Generated reference for the mutation endpoint tasks/move."
+title: "Tasks API: Move"
+description: "Reference for the move mutation in the Tasks API."
 ---
 
 import CurlExampleBlock from "@components/CurlExampleBlock.jsx"

--- a/src/content/docs/help/api/tasks/update_assignee.mdx
+++ b/src/content/docs/help/api/tasks/update_assignee.mdx
@@ -1,6 +1,6 @@
 ---
-title: "update_assignee"
-description: "Generated reference for the mutation endpoint tasks/update_assignee."
+title: "Tasks API: Update assignee"
+description: "Reference for the update assignee mutation in the Tasks API."
 ---
 
 import CurlExampleBlock from "@components/CurlExampleBlock.jsx"

--- a/src/content/docs/help/api/tasks/update_description.mdx
+++ b/src/content/docs/help/api/tasks/update_description.mdx
@@ -1,6 +1,6 @@
 ---
-title: "update_description"
-description: "Generated reference for the mutation endpoint tasks/update_description."
+title: "Tasks API: Update description"
+description: "Reference for the update description mutation in the Tasks API."
 ---
 
 import CurlExampleBlock from "@components/CurlExampleBlock.jsx"

--- a/src/content/docs/help/api/tasks/update_due_date.mdx
+++ b/src/content/docs/help/api/tasks/update_due_date.mdx
@@ -1,6 +1,6 @@
 ---
-title: "update_due_date"
-description: "Generated reference for the mutation endpoint tasks/update_due_date."
+title: "Tasks API: Update due date"
+description: "Reference for the update due date mutation in the Tasks API."
 ---
 
 import CurlExampleBlock from "@components/CurlExampleBlock.jsx"

--- a/src/content/docs/help/api/tasks/update_milestone.mdx
+++ b/src/content/docs/help/api/tasks/update_milestone.mdx
@@ -1,6 +1,6 @@
 ---
-title: "update_milestone"
-description: "Generated reference for the mutation endpoint tasks/update_milestone."
+title: "Tasks API: Update milestone"
+description: "Reference for the update milestone mutation in the Tasks API."
 ---
 
 import CurlExampleBlock from "@components/CurlExampleBlock.jsx"

--- a/src/content/docs/help/api/tasks/update_milestone_and_ordering.mdx
+++ b/src/content/docs/help/api/tasks/update_milestone_and_ordering.mdx
@@ -1,6 +1,6 @@
 ---
-title: "update_milestone_and_ordering"
-description: "Generated reference for the mutation endpoint tasks/update_milestone_and_ordering."
+title: "Tasks API: Update milestone and ordering"
+description: "Reference for the update milestone and ordering mutation in the Tasks API."
 ---
 
 import CurlExampleBlock from "@components/CurlExampleBlock.jsx"

--- a/src/content/docs/help/api/tasks/update_name.mdx
+++ b/src/content/docs/help/api/tasks/update_name.mdx
@@ -1,6 +1,6 @@
 ---
-title: "update_name"
-description: "Generated reference for the mutation endpoint tasks/update_name."
+title: "Tasks API: Update name"
+description: "Reference for the update name mutation in the Tasks API."
 ---
 
 import CurlExampleBlock from "@components/CurlExampleBlock.jsx"

--- a/src/content/docs/help/api/tasks/update_status.mdx
+++ b/src/content/docs/help/api/tasks/update_status.mdx
@@ -1,6 +1,6 @@
 ---
-title: "update_status"
-description: "Generated reference for the mutation endpoint tasks/update_status."
+title: "Tasks API: Update status"
+description: "Reference for the update status mutation in the Tasks API."
 ---
 
 import CurlExampleBlock from "@components/CurlExampleBlock.jsx"

--- a/src/content/docs/help/cli-authentication.mdx
+++ b/src/content/docs/help/cli-authentication.mdx
@@ -1,5 +1,5 @@
 ---
-title: Authentication
+title: CLI authentication
 description: Learn how to authenticate the Operately CLI with API tokens, profiles, and environment variables.
 ---
 

--- a/src/content/docs/help/cli-installation.mdx
+++ b/src/content/docs/help/cli-installation.mdx
@@ -1,5 +1,5 @@
 ---
-title: Install and update
+title: CLI install and update
 description: Learn how to install, update, and verify the Operately CLI.
 ---
 

--- a/src/content/docs/help/cli-skills.mdx
+++ b/src/content/docs/help/cli-skills.mdx
@@ -1,5 +1,5 @@
 ---
-title: Install skills
+title: CLI skills
 description: Learn how to install the Operately skills with the skills package from npm.
 ---
 

--- a/src/content/docs/help/cli-usage.mdx
+++ b/src/content/docs/help/cli-usage.mdx
@@ -1,5 +1,5 @@
 ---
-title: Use the CLI
+title: Use the Operately CLI
 description: Learn the Operately CLI command shape, help system, and a few common examples.
 ---
 

--- a/src/content/docs/help/cli.mdx
+++ b/src/content/docs/help/cli.mdx
@@ -1,5 +1,5 @@
 ---
-title: CLI
+title: Operately CLI
 description: Learn how to use the Operately CLI to work with the external API from your terminal.
 ---
 

--- a/src/content/docs/help/create-api-token.mdx
+++ b/src/content/docs/help/create-api-token.mdx
@@ -31,3 +31,9 @@ After you close the token modal, you will not be able to view the full token aga
 - You can rename tokens to keep them organized.
 - You can change an existing token between **Read-only** and **Full-access**.
 - You can delete a token at any time.
+
+## What to read next
+
+- [CLI authentication](/help/cli-authentication)
+- [Operately CLI overview](/help/cli)
+- [Operately API docs](/help/api)

--- a/src/content/docs/help/self-hosted-beacon.mdx
+++ b/src/content/docs/help/self-hosted-beacon.mdx
@@ -1,5 +1,5 @@
 ---
-title: Beacon
+title: Self-hosted beacon
 description: Learn about Operately's beacon system, how it works, and how to disable it.
 ---
 

--- a/src/content/docs/help/self-hosted-email-delivery/index.mdx
+++ b/src/content/docs/help/self-hosted-email-delivery/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: Email Delivery
+title: Self-hosted email delivery
 description: Learn how to configure email delivery for your self-hosted Operately installation using SendGrid API or SMTP.
 ---
 

--- a/src/content/docs/help/self-hosted-google-sign-in.mdx
+++ b/src/content/docs/help/self-hosted-google-sign-in.mdx
@@ -1,5 +1,5 @@
 ---
-title: Google Sign-In
+title: Self-hosted Google Sign-In
 description: Learn how to enable Google Sign-In (OAuth) for your self-hosted Operately installation.
 ---
 

--- a/src/content/docs/help/self-hosted-installation.mdx
+++ b/src/content/docs/help/self-hosted-installation.mdx
@@ -1,5 +1,5 @@
 ---
-title: Installation
+title: Self-hosted installation
 description: Learn how to download and install Operately on your own infrastructure.
 ---
 

--- a/src/content/docs/help/self-hosted-update.mdx
+++ b/src/content/docs/help/self-hosted-update.mdx
@@ -1,5 +1,5 @@
 ---
-title: Update Version
+title: Update a self-hosted installation
 description: Learn how to update your self-hosted Operately installation to a newer version.
 ---
 


### PR DESCRIPTION
## Summary
- replace raw API doc slug titles and boilerplate descriptions with human-readable, namespace-aware metadata
- humanize API namespace index link labels and improve the API landing page with token + CLI entry points
- tighten a few priority help titles and fix the external-link description outlier for more consistent search snippets

## Validation
- `npm run build`

Closes operately/gtm-context#8
