### PR TITLE
Improve non-API help docs SEO metadata

### DIFF
--- a/src/content/docs/help/add-external-link/index.mdx
+++ b/src/content/docs/help/add-external-link/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Add an External Link"
-description: "Add an link to an external service or document."
+description: "Add a link to an external service, website, or document."
 ---
 
 import ImageEnhancer from '@/components/ImageEnhancer.astro';

--- a/src/content/docs/help/cli-authentication.mdx
+++ b/src/content/docs/help/cli-authentication.mdx
@@ -1,5 +1,5 @@
 ---
-title: Authentication
+title: CLI authentication
 description: Learn how to authenticate the Operately CLI with API tokens, profiles, and environment variables.
 ---
 

--- a/src/content/docs/help/cli-installation.mdx
+++ b/src/content/docs/help/cli-installation.mdx
@@ -1,5 +1,5 @@
 ---
-title: Install and update
+title: CLI install and update
 description: Learn how to install, update, and verify the Operately CLI.
 ---
 

--- a/src/content/docs/help/cli-skills.mdx
+++ b/src/content/docs/help/cli-skills.mdx
@@ -1,5 +1,5 @@
 ---
-title: Install skills
+title: CLI skills
 description: Learn how to install the Operately skills with the skills package from npm.
 ---
 

--- a/src/content/docs/help/cli-usage.mdx
+++ b/src/content/docs/help/cli-usage.mdx
@@ -1,5 +1,5 @@
 ---
-title: Use the CLI
+title: Use the Operately CLI
 description: Learn the Operately CLI command shape, help system, and a few common examples.
 ---
 

--- a/src/content/docs/help/cli.mdx
+++ b/src/content/docs/help/cli.mdx
@@ -1,5 +1,5 @@
 ---
-title: CLI
+title: Operately CLI
 description: Learn how to use the Operately CLI to work with the external API from your terminal.
 ---
 

--- a/src/content/docs/help/create-api-token.mdx
+++ b/src/content/docs/help/create-api-token.mdx
@@ -31,3 +31,9 @@ After you close the token modal, you will not be able to view the full token aga
 - You can rename tokens to keep them organized.
 - You can change an existing token between **Read-only** and **Full-access**.
 - You can delete a token at any time.
+
+## What to read next
+
+- [CLI authentication](/help/cli-authentication)
+- [Operately CLI overview](/help/cli)
+- [Operately API docs](/help/api)

--- a/src/content/docs/help/self-hosted-beacon.mdx
+++ b/src/content/docs/help/self-hosted-beacon.mdx
@@ -1,5 +1,5 @@
 ---
-title: Beacon
+title: Self-hosted beacon
 description: Learn about Operately's beacon system, how it works, and how to disable it.
 ---
 

--- a/src/content/docs/help/self-hosted-email-delivery/index.mdx
+++ b/src/content/docs/help/self-hosted-email-delivery/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: Email Delivery
+title: Self-hosted email delivery
 description: Learn how to configure email delivery for your self-hosted Operately installation using SendGrid API or SMTP.
 ---
 

--- a/src/content/docs/help/self-hosted-google-sign-in.mdx
+++ b/src/content/docs/help/self-hosted-google-sign-in.mdx
@@ -1,5 +1,5 @@
 ---
-title: Google Sign-In
+title: Self-hosted Google Sign-In
 description: Learn how to enable Google Sign-In (OAuth) for your self-hosted Operately installation.
 ---
 

--- a/src/content/docs/help/self-hosted-installation.mdx
+++ b/src/content/docs/help/self-hosted-installation.mdx
@@ -1,5 +1,5 @@
 ---
-title: Installation
+title: Self-hosted installation
 description: Learn how to download and install Operately on your own infrastructure.
 ---
 

--- a/src/content/docs/help/self-hosted-update.mdx
+++ b/src/content/docs/help/self-hosted-update.mdx
@@ -1,5 +1,5 @@
 ---
-title: Update Version
+title: Update a self-hosted installation
 description: Learn how to update your self-hosted Operately installation to a newer version.
 ---
 


### PR DESCRIPTION
## Summary
- improve SEO-facing titles for key non-API help pages, especially CLI and self-hosted setup docs
- add next-step links on the API token guide to strengthen internal navigation to related docs
- fix the `add-external-link` description typo so the page has a cleaner search snippet

## Validation
- `npm run build`

## Notes
- This PR intentionally excludes autogenerated `/help/api/*` docs so it can merge safely.
- Supersedes #271 for the website-only portion of the work.

Closes operately/gtm-context#8
