### PR TITLE
Add /vs/monday and /vs/asana comparison pages

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -2,6 +2,7 @@ import { defineConfig } from "astro/config";
 import react from "@astrojs/react";
 import starlight from "@astrojs/starlight";
 import tailwindcss from "@tailwindcss/vite";
+import sitemap from "@astrojs/sitemap";
 
 import mdx from "@astrojs/mdx";
 import rehypeSlug from "rehype-slug";
@@ -14,6 +15,7 @@ export default defineConfig({
   site: "https://operately.com",
   integrations: [
     react(),
+    sitemap(),
     starlight(helpCenterSidebar()),
     mdx({
       remarkPlugins: [],

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@astrojs/mdx": "^4.3.5",
         "@astrojs/react": "^4.3.1",
         "@astrojs/rss": "^4.0.12",
+        "@astrojs/sitemap": "^3.7.2",
         "@astrojs/starlight": "^0.35.2",
         "@headlessui/react": "^2.2.0",
         "@tailwindcss/typography": "^0.5.16",
@@ -158,14 +159,23 @@
       }
     },
     "node_modules/@astrojs/sitemap": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@astrojs/sitemap/-/sitemap-3.3.0.tgz",
-      "integrity": "sha512-nYE4lKQtk+Kbrw/w0G0TTgT724co0jUsU4tPlHY9au5HmTBKbwiCLwO/15b1/y13aZ4Kr9ZbMeMHlXuwn0ty4Q==",
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/@astrojs/sitemap/-/sitemap-3.7.2.tgz",
+      "integrity": "sha512-PqkzkcZTb5ICiyIR8VoKbIAP/laNRXi5tw616N1Ckk+40oNB8Can1AzVV56lrbC5GKSZFCyJYUVYqVivMisvpA==",
       "license": "MIT",
       "dependencies": {
-        "sitemap": "^8.0.0",
+        "sitemap": "^9.0.0",
         "stream-replace-string": "^2.0.0",
-        "zod": "^3.24.2"
+        "zod": "^4.3.6"
+      }
+    },
+    "node_modules/@astrojs/sitemap/node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/@astrojs/starlight": {
@@ -2784,12 +2794,12 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "22.14.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.14.1.tgz",
-      "integrity": "sha512-u0HuPQwe/dHrItgHHpmw3N2fYCR6x4ivMNbPHRkBVP4CvN+kiRrKHWk3i8tXiO/joPwXLMYvF9TTF0eqgHIuOw==",
+      "version": "24.12.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.2.tgz",
+      "integrity": "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==",
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.21.0"
+        "undici-types": "~7.16.0"
       }
     },
     "node_modules/@types/prop-types": {
@@ -8264,10 +8274,13 @@
       }
     },
     "node_modules/sax": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.4.1.tgz",
-      "integrity": "sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg==",
-      "license": "ISC"
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
+      "integrity": "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=11.0.0"
+      }
     },
     "node_modules/scheduler": {
       "version": "0.23.2",
@@ -8388,29 +8401,23 @@
       "license": "MIT"
     },
     "node_modules/sitemap": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/sitemap/-/sitemap-8.0.0.tgz",
-      "integrity": "sha512-+AbdxhM9kJsHtruUF39bwS/B0Fytw6Fr1o4ZAIAEqA6cke2xcoO2GleBw9Zw7nRzILVEgz7zBM5GiTJjie1G9A==",
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/sitemap/-/sitemap-9.0.1.tgz",
+      "integrity": "sha512-S6hzjGJSG3d6if0YoF5kTyeRJvia6FSTBroE5fQ0bu1QNxyJqhhinfUsXi9fH3MgtXODWvwo2BDyQSnhPQ88uQ==",
       "license": "MIT",
       "dependencies": {
-        "@types/node": "^17.0.5",
+        "@types/node": "^24.9.2",
         "@types/sax": "^1.2.1",
         "arg": "^5.0.0",
-        "sax": "^1.2.4"
+        "sax": "^1.4.1"
       },
       "bin": {
-        "sitemap": "dist/cli.js"
+        "sitemap": "dist/esm/cli.js"
       },
       "engines": {
-        "node": ">=14.0.0",
-        "npm": ">=6.0.0"
+        "node": ">=20.19.5",
+        "npm": ">=10.8.2"
       }
-    },
-    "node_modules/sitemap/node_modules/@types/node": {
-      "version": "17.0.45",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.45.tgz",
-      "integrity": "sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw==",
-      "license": "MIT"
     },
     "node_modules/smol-toml": {
       "version": "1.4.2",
@@ -8787,9 +8794,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
       "license": "MIT"
     },
     "node_modules/unenv": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@astrojs/mdx": "^4.3.5",
     "@astrojs/react": "^4.3.1",
     "@astrojs/rss": "^4.0.12",
+    "@astrojs/sitemap": "^3.7.2",
     "@astrojs/starlight": "^0.35.2",
     "@headlessui/react": "^2.2.0",
     "@tailwindcss/typography": "^0.5.16",

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -23,6 +23,10 @@ const navigation = {
     { name: "Status", href: "https://status.operately.com" },
     { name: "GitHub", href: "https://github.com/operately/operately" },
   ],
+  compare: [
+    { name: "vs Monday.com", href: "/vs/monday" },
+    { name: "vs Asana", href: "/vs/asana" },
+  ],
   resources: [
     { name: "Help center", href: "/help" },
     { name: "Blog", href: "https://blog.operately.com" },
@@ -166,6 +170,22 @@ const navigation = {
             <ul role="list" class="mt-6 space-y-4">
               {
                 navigation.getStarted.map((item) => (
+                  <li>
+                    <a
+                      href={item.href}
+                      class="text-sm/6 text-gray-600 hover:text-operately-blue"
+                    >
+                      {item.name}
+                    </a>
+                  </li>
+                ))
+              }
+            </ul>
+
+            <h3 class="mt-10 text-sm/6 font-semibold text-gray-900">Compare</h3>
+            <ul role="list" class="mt-6 space-y-4">
+              {
+                navigation.compare.map((item) => (
                   <li>
                     <a
                       href={item.href}

--- a/src/pages/vs/asana.astro
+++ b/src/pages/vs/asana.astro
@@ -1,0 +1,294 @@
+---
+import BaseLayout from "../../layouts/BaseLayout.astro";
+
+const pageTitle = "Operately vs Asana";
+const pageDescription =
+  "Comparing Operately and Asana: open source vs closed, goal-driven vs task-driven, flat pricing vs per-seat. Find out which fits your team.";
+
+const schema = {
+  "@type": "WebPage",
+  "@id": "https://operately.com/vs/asana/#webpage",
+  url: "https://operately.com/vs/asana/",
+  name: pageTitle,
+  description: pageDescription,
+  isPartOf: {
+    "@id": "https://operately.com/#website",
+  },
+  about: {
+    "@id": "https://operately.com/#organization",
+  },
+};
+
+const signUpUrl = import.meta.env.SIGN_UP_URL;
+---
+
+<BaseLayout
+  title={pageTitle}
+  description={pageDescription}
+  image="/images/social/card-summary-large.png"
+  twitterCardType="summary_large_image"
+  schema={schema}
+>
+  <main class="bg-white py-8 sm:py-16">
+    <div class="mx-auto max-w-5xl px-6 lg:px-8">
+      {/* Hero */}
+      <div class="mx-auto max-w-3xl text-center">
+        <p class="text-sm font-semibold uppercase tracking-wide text-operately-blue">
+          Comparison
+        </p>
+        <h1 class="mt-3 text-balance text-4xl font-semibold tracking-tight text-gray-900 sm:text-5xl">
+          Operately vs Asana
+        </h1>
+        <p class="mt-6 text-lg leading-8 text-gray-600">
+          Asana is one of the largest project management platforms. Operately is an open source
+          alternative that focuses on goals, projects, and structured execution without per-seat pricing.
+        </p>
+      </div>
+
+      {/* Quick summary */}
+      <div class="mx-auto mt-16 grid max-w-4xl gap-6 sm:grid-cols-2">
+        <div class="rounded-2xl border border-gray-200 p-6">
+          <h3 class="text-lg font-semibold text-gray-900">Asana</h3>
+          <ul class="mt-4 space-y-2 text-sm text-gray-600">
+            <li class="flex items-start gap-2">
+              <span class="mt-0.5 text-gray-400">&#x2022;</span>
+              Closed source, cloud-only
+            </li>
+            <li class="flex items-start gap-2">
+              <span class="mt-0.5 text-gray-400">&#x2022;</span>
+              Per-seat pricing, starts at $10.99/user/mo
+            </li>
+            <li class="flex items-start gap-2">
+              <span class="mt-0.5 text-gray-400">&#x2022;</span>
+              Task, project, and portfolio management
+            </li>
+            <li class="flex items-start gap-2">
+              <span class="mt-0.5 text-gray-400">&#x2022;</span>
+              Goals feature available on Business plan and above
+            </li>
+            <li class="flex items-start gap-2">
+              <span class="mt-0.5 text-gray-400">&#x2022;</span>
+              Large ecosystem of integrations
+            </li>
+          </ul>
+        </div>
+
+        <div class="rounded-2xl border-2 border-operately-blue p-6">
+          <h3 class="text-lg font-semibold text-gray-900">Operately</h3>
+          <ul class="mt-4 space-y-2 text-sm text-gray-600">
+            <li class="flex items-start gap-2">
+              <span class="mt-0.5 text-operately-blue">&#x2022;</span>
+              Open source, self-host or cloud
+            </li>
+            <li class="flex items-start gap-2">
+              <span class="mt-0.5 text-operately-blue">&#x2022;</span>
+              Flat-rate pricing, no per-seat costs
+            </li>
+            <li class="flex items-start gap-2">
+              <span class="mt-0.5 text-operately-blue">&#x2022;</span>
+              Goals and OKRs are core, not an add-on
+            </li>
+            <li class="flex items-start gap-2">
+              <span class="mt-0.5 text-operately-blue">&#x2022;</span>
+              CLI, API, and AI agent integration built in
+            </li>
+            <li class="flex items-start gap-2">
+              <span class="mt-0.5 text-operately-blue">&#x2022;</span>
+              Structured check-ins and progress workflows
+            </li>
+          </ul>
+        </div>
+      </div>
+
+      {/* Comparison table */}
+      <div class="mx-auto mt-16 max-w-4xl">
+        <h2 class="text-2xl font-semibold text-gray-900">Feature comparison</h2>
+        <div class="mt-8 overflow-hidden rounded-xl border border-gray-200">
+          <table class="w-full text-sm">
+            <thead>
+              <tr class="border-b border-gray-200 bg-gray-50">
+                <th class="px-6 py-3 text-left font-medium text-gray-500"></th>
+                <th class="px-6 py-3 text-center font-medium text-gray-900">Operately</th>
+                <th class="px-6 py-3 text-center font-medium text-gray-900">Asana</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-gray-200">
+              <tr>
+                <td class="px-6 py-4 font-medium text-gray-900">Open source</td>
+                <td class="px-6 py-4 text-center text-green-600">Yes</td>
+                <td class="px-6 py-4 text-center text-gray-400">No</td>
+              </tr>
+              <tr>
+                <td class="px-6 py-4 font-medium text-gray-900">Self-hosted option</td>
+                <td class="px-6 py-4 text-center text-green-600">Yes</td>
+                <td class="px-6 py-4 text-center text-gray-400">No</td>
+              </tr>
+              <tr>
+                <td class="px-6 py-4 font-medium text-gray-900">Pricing model</td>
+                <td class="px-6 py-4 text-center">Flat rate</td>
+                <td class="px-6 py-4 text-center">Per seat</td>
+              </tr>
+              <tr>
+                <td class="px-6 py-4 font-medium text-gray-900">OKRs and goals</td>
+                <td class="px-6 py-4 text-center text-green-600">Core feature</td>
+                <td class="px-6 py-4 text-center">Business+ plans only</td>
+              </tr>
+              <tr>
+                <td class="px-6 py-4 font-medium text-gray-900">Structured check-ins</td>
+                <td class="px-6 py-4 text-center text-green-600">Built-in</td>
+                <td class="px-6 py-4 text-center">Status updates</td>
+              </tr>
+              <tr>
+                <td class="px-6 py-4 font-medium text-gray-900">CLI access</td>
+                <td class="px-6 py-4 text-center text-green-600">Yes</td>
+                <td class="px-6 py-4 text-center text-gray-400">No</td>
+              </tr>
+              <tr>
+                <td class="px-6 py-4 font-medium text-gray-900">API-first design</td>
+                <td class="px-6 py-4 text-center text-green-600">Yes</td>
+                <td class="px-6 py-4 text-center">REST API available</td>
+              </tr>
+              <tr>
+                <td class="px-6 py-4 font-medium text-gray-900">AI agent integration</td>
+                <td class="px-6 py-4 text-center text-green-600">Native</td>
+                <td class="px-6 py-4 text-center">AI features (Asana Intelligence)</td>
+              </tr>
+              <tr>
+                <td class="px-6 py-4 font-medium text-gray-900">Task management</td>
+                <td class="px-6 py-4 text-center text-green-600">Yes</td>
+                <td class="px-6 py-4 text-center text-green-600">Yes (extensive)</td>
+              </tr>
+              <tr>
+                <td class="px-6 py-4 font-medium text-gray-900">Portfolios</td>
+                <td class="px-6 py-4 text-center text-gray-400">No</td>
+                <td class="px-6 py-4 text-center text-green-600">Yes</td>
+              </tr>
+              <tr>
+                <td class="px-6 py-4 font-medium text-gray-900">Timeline / Gantt</td>
+                <td class="px-6 py-4 text-center text-gray-400">No</td>
+                <td class="px-6 py-4 text-center text-green-600">Yes</td>
+              </tr>
+              <tr>
+                <td class="px-6 py-4 font-medium text-gray-900">Third-party integrations</td>
+                <td class="px-6 py-4 text-center">Growing</td>
+                <td class="px-6 py-4 text-center text-green-600">200+ native</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      {/* When to choose sections */}
+      <div class="mx-auto mt-16 max-w-4xl">
+        <h2 class="text-2xl font-semibold text-gray-900">When to choose Operately</h2>
+        <ul class="mt-6 space-y-3 text-gray-600">
+          <li class="flex items-start gap-3">
+            <svg class="mt-1 h-5 w-5 flex-shrink-0 text-operately-blue" fill="currentColor" viewBox="0 0 20 20">
+              <path fill-rule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clip-rule="evenodd"/>
+            </svg>
+            <span>You want open source software you can self-host and control</span>
+          </li>
+          <li class="flex items-start gap-3">
+            <svg class="mt-1 h-5 w-5 flex-shrink-0 text-operately-blue" fill="currentColor" viewBox="0 0 20 20">
+              <path fill-rule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clip-rule="evenodd"/>
+            </svg>
+            <span>Goals and OKRs are central to how your team works, not a bolt-on</span>
+          </li>
+          <li class="flex items-start gap-3">
+            <svg class="mt-1 h-5 w-5 flex-shrink-0 text-operately-blue" fill="currentColor" viewBox="0 0 20 20">
+              <path fill-rule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clip-rule="evenodd"/>
+            </svg>
+            <span>Per-seat pricing is a concern as your team grows</span>
+          </li>
+          <li class="flex items-start gap-3">
+            <svg class="mt-1 h-5 w-5 flex-shrink-0 text-operately-blue" fill="currentColor" viewBox="0 0 20 20">
+              <path fill-rule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clip-rule="evenodd"/>
+            </svg>
+            <span>You work with or plan to use AI agents in your workflow</span>
+          </li>
+          <li class="flex items-start gap-3">
+            <svg class="mt-1 h-5 w-5 flex-shrink-0 text-operately-blue" fill="currentColor" viewBox="0 0 20 20">
+              <path fill-rule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clip-rule="evenodd"/>
+            </svg>
+            <span>You want a lighter tool without enterprise complexity you do not use</span>
+          </li>
+        </ul>
+      </div>
+
+      <div class="mx-auto mt-12 max-w-4xl">
+        <h2 class="text-2xl font-semibold text-gray-900">When Asana might be better</h2>
+        <ul class="mt-6 space-y-3 text-gray-600">
+          <li class="flex items-start gap-3">
+            <svg class="mt-1 h-5 w-5 flex-shrink-0 text-gray-400" fill="currentColor" viewBox="0 0 20 20">
+              <path fill-rule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clip-rule="evenodd"/>
+            </svg>
+            <span>You need advanced task management with subtasks, dependencies, and timelines</span>
+          </li>
+          <li class="flex items-start gap-3">
+            <svg class="mt-1 h-5 w-5 flex-shrink-0 text-gray-400" fill="currentColor" viewBox="0 0 20 20">
+              <path fill-rule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clip-rule="evenodd"/>
+            </svg>
+            <span>You need a large library of native integrations (Slack, Salesforce, Jira, etc.)</span>
+          </li>
+          <li class="flex items-start gap-3">
+            <svg class="mt-1 h-5 w-5 flex-shrink-0 text-gray-400" fill="currentColor" viewBox="0 0 20 20">
+              <path fill-rule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clip-rule="evenodd"/>
+            </svg>
+            <span>Your organization is large and needs portfolio-level visibility across many teams</span>
+          </li>
+          <li class="flex items-start gap-3">
+            <svg class="mt-1 h-5 w-5 flex-shrink-0 text-gray-400" fill="currentColor" viewBox="0 0 20 20">
+              <path fill-rule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clip-rule="evenodd"/>
+            </svg>
+            <span>You need Gantt charts, workload management, and resource planning</span>
+          </li>
+        </ul>
+      </div>
+
+      {/* Philosophy section */}
+      <div class="mx-auto mt-16 max-w-4xl">
+        <h2 class="text-2xl font-semibold text-gray-900">Different philosophies</h2>
+        <div class="mt-6 space-y-4 text-gray-600 leading-7">
+          <p>
+            Asana is a comprehensive work management platform built for organizations that need
+            to coordinate complex projects across many teams. It excels at task management, timelines,
+            and portfolio visibility, with goals added as a higher-tier feature.
+          </p>
+          <p>
+            Operately starts from the other direction: goals and outcomes first, with projects and tasks
+            in service of those goals. Structured check-ins make progress visible without requiring teams
+            to maintain complex board configurations. And because it is open source, you always have
+            the option to self-host, inspect the code, or extend it.
+          </p>
+          <p>
+            The core trade-off: Asana offers a wider, more mature feature set with a large ecosystem.
+            Operately offers a focused, opinionated approach to goal-driven execution with open source
+            transparency, flat pricing, and a developer-friendly architecture.
+          </p>
+        </div>
+      </div>
+
+      {/* CTA */}
+      <div class="mx-auto mt-16 max-w-3xl text-center">
+        <h2 class="text-2xl font-semibold text-gray-900">Try Operately</h2>
+        <p class="mt-4 text-gray-600">
+          Start with Operately Cloud for free, or self-host it on your own infrastructure.
+        </p>
+        <div class="mt-8 flex flex-col gap-4 sm:flex-row sm:justify-center">
+          <a
+            href={signUpUrl}
+            class="inline-flex items-center justify-center rounded-md bg-edgy-blue px-5 py-3 text-sm font-semibold text-white shadow-sm hover:bg-operately-dark-blue"
+          >
+            Start free on Cloud
+          </a>
+          <a
+            href="/self-hosted"
+            class="inline-flex items-center justify-center rounded-md border border-gray-300 px-5 py-3 text-sm font-semibold text-gray-900 hover:border-operately-blue hover:text-operately-blue"
+          >
+            Self-host Operately
+          </a>
+        </div>
+      </div>
+    </div>
+  </main>
+</BaseLayout>

--- a/src/pages/vs/asana.astro
+++ b/src/pages/vs/asana.astro
@@ -45,6 +45,26 @@ const signUpUrl = import.meta.env.SIGN_UP_URL;
         </p>
       </div>
 
+      {/* Key differentiators bar */}
+      <div class="mx-auto mt-10 flex max-w-3xl flex-wrap justify-center gap-4">
+        <span class="inline-flex items-center gap-1.5 rounded-full bg-operately-blue-tint-1 px-4 py-1.5 text-sm font-medium text-operately-dark-blue">
+          <svg class="h-4 w-4" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clip-rule="evenodd"/></svg>
+          Open source
+        </span>
+        <span class="inline-flex items-center gap-1.5 rounded-full bg-operately-blue-tint-1 px-4 py-1.5 text-sm font-medium text-operately-dark-blue">
+          <svg class="h-4 w-4" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clip-rule="evenodd"/></svg>
+          Self-hostable
+        </span>
+        <span class="inline-flex items-center gap-1.5 rounded-full bg-operately-blue-tint-1 px-4 py-1.5 text-sm font-medium text-operately-dark-blue">
+          <svg class="h-4 w-4" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clip-rule="evenodd"/></svg>
+          No per-seat pricing
+        </span>
+        <span class="inline-flex items-center gap-1.5 rounded-full bg-operately-blue-tint-1 px-4 py-1.5 text-sm font-medium text-operately-dark-blue">
+          <svg class="h-4 w-4" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clip-rule="evenodd"/></svg>
+          Goals-first design
+        </span>
+      </div>
+
       {/* Quick summary */}
       <div class="mx-auto mt-16 grid max-w-4xl gap-6 sm:grid-cols-2">
         <div class="rounded-2xl border border-gray-200 p-6">
@@ -178,6 +198,17 @@ const signUpUrl = import.meta.env.SIGN_UP_URL;
         </div>
       </div>
 
+      {/* Mid-page CTA */}
+      <div class="mx-auto mt-12 max-w-4xl rounded-xl bg-gray-50 p-6 text-center">
+        <p class="text-sm font-medium text-gray-900">Want to see Operately in action?</p>
+        <a
+          href={signUpUrl}
+          class="mt-3 inline-flex items-center justify-center rounded-md bg-edgy-blue px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-operately-dark-blue"
+        >
+          Try free — no credit card needed
+        </a>
+      </div>
+
       {/* When to choose sections */}
       <div class="mx-auto mt-16 max-w-4xl">
         <h2 class="text-2xl font-semibold text-gray-900">When to choose Operately</h2>
@@ -273,6 +304,7 @@ const signUpUrl = import.meta.env.SIGN_UP_URL;
         <h2 class="text-2xl font-semibold text-gray-900">Try Operately</h2>
         <p class="mt-4 text-gray-600">
           Start with Operately Cloud for free, or self-host it on your own infrastructure.
+          No credit card required.
         </p>
         <div class="mt-8 flex flex-col gap-4 sm:flex-row sm:justify-center">
           <a

--- a/src/pages/vs/monday.astro
+++ b/src/pages/vs/monday.astro
@@ -1,0 +1,288 @@
+---
+import BaseLayout from "../../layouts/BaseLayout.astro";
+
+const pageTitle = "Operately vs Monday.com";
+const pageDescription =
+  "Comparing Operately and Monday.com: open source vs closed, self-hosted vs cloud-only, goal-driven vs task-driven. Find out which fits your team.";
+
+const schema = {
+  "@type": "WebPage",
+  "@id": "https://operately.com/vs/monday/#webpage",
+  url: "https://operately.com/vs/monday/",
+  name: pageTitle,
+  description: pageDescription,
+  isPartOf: {
+    "@id": "https://operately.com/#website",
+  },
+  about: {
+    "@id": "https://operately.com/#organization",
+  },
+};
+
+const signUpUrl = import.meta.env.SIGN_UP_URL;
+---
+
+<BaseLayout
+  title={pageTitle}
+  description={pageDescription}
+  image="/images/social/card-summary-large.png"
+  twitterCardType="summary_large_image"
+  schema={schema}
+>
+  <main class="bg-white py-8 sm:py-16">
+    <div class="mx-auto max-w-5xl px-6 lg:px-8">
+      {/* Hero */}
+      <div class="mx-auto max-w-3xl text-center">
+        <p class="text-sm font-semibold uppercase tracking-wide text-operately-blue">
+          Comparison
+        </p>
+        <h1 class="mt-3 text-balance text-4xl font-semibold tracking-tight text-gray-900 sm:text-5xl">
+          Operately vs Monday.com
+        </h1>
+        <p class="mt-6 text-lg leading-8 text-gray-600">
+          Monday.com is a popular work management platform. Operately is an open source alternative
+          built for teams that want goals, projects, and execution in one place without vendor lock-in.
+        </p>
+      </div>
+
+      {/* Quick summary */}
+      <div class="mx-auto mt-16 grid max-w-4xl gap-6 sm:grid-cols-2">
+        <div class="rounded-2xl border border-gray-200 p-6">
+          <h3 class="text-lg font-semibold text-gray-900">Monday.com</h3>
+          <ul class="mt-4 space-y-2 text-sm text-gray-600">
+            <li class="flex items-start gap-2">
+              <span class="mt-0.5 text-gray-400">&#x2022;</span>
+              Closed source, cloud-only
+            </li>
+            <li class="flex items-start gap-2">
+              <span class="mt-0.5 text-gray-400">&#x2022;</span>
+              Per-seat pricing, starts at $9/seat/mo
+            </li>
+            <li class="flex items-start gap-2">
+              <span class="mt-0.5 text-gray-400">&#x2022;</span>
+              Task and workflow focused
+            </li>
+            <li class="flex items-start gap-2">
+              <span class="mt-0.5 text-gray-400">&#x2022;</span>
+              Visual boards and automations
+            </li>
+            <li class="flex items-start gap-2">
+              <span class="mt-0.5 text-gray-400">&#x2022;</span>
+              Enterprise-scale feature set
+            </li>
+          </ul>
+        </div>
+
+        <div class="rounded-2xl border-2 border-operately-blue p-6">
+          <h3 class="text-lg font-semibold text-gray-900">Operately</h3>
+          <ul class="mt-4 space-y-2 text-sm text-gray-600">
+            <li class="flex items-start gap-2">
+              <span class="mt-0.5 text-operately-blue">&#x2022;</span>
+              Open source, self-host or cloud
+            </li>
+            <li class="flex items-start gap-2">
+              <span class="mt-0.5 text-operately-blue">&#x2022;</span>
+              Flat-rate pricing, no per-seat costs
+            </li>
+            <li class="flex items-start gap-2">
+              <span class="mt-0.5 text-operately-blue">&#x2022;</span>
+              Goal and outcome focused (OKRs, projects, check-ins)
+            </li>
+            <li class="flex items-start gap-2">
+              <span class="mt-0.5 text-operately-blue">&#x2022;</span>
+              CLI, API, and agent-friendly by design
+            </li>
+            <li class="flex items-start gap-2">
+              <span class="mt-0.5 text-operately-blue">&#x2022;</span>
+              Lightweight, no enterprise bloat
+            </li>
+          </ul>
+        </div>
+      </div>
+
+      {/* Comparison table */}
+      <div class="mx-auto mt-16 max-w-4xl">
+        <h2 class="text-2xl font-semibold text-gray-900">Feature comparison</h2>
+        <div class="mt-8 overflow-hidden rounded-xl border border-gray-200">
+          <table class="w-full text-sm">
+            <thead>
+              <tr class="border-b border-gray-200 bg-gray-50">
+                <th class="px-6 py-3 text-left font-medium text-gray-500"></th>
+                <th class="px-6 py-3 text-center font-medium text-gray-900">Operately</th>
+                <th class="px-6 py-3 text-center font-medium text-gray-900">Monday.com</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-gray-200">
+              <tr>
+                <td class="px-6 py-4 font-medium text-gray-900">Open source</td>
+                <td class="px-6 py-4 text-center text-green-600">Yes</td>
+                <td class="px-6 py-4 text-center text-gray-400">No</td>
+              </tr>
+              <tr>
+                <td class="px-6 py-4 font-medium text-gray-900">Self-hosted option</td>
+                <td class="px-6 py-4 text-center text-green-600">Yes</td>
+                <td class="px-6 py-4 text-center text-gray-400">No</td>
+              </tr>
+              <tr>
+                <td class="px-6 py-4 font-medium text-gray-900">Pricing model</td>
+                <td class="px-6 py-4 text-center">Flat rate</td>
+                <td class="px-6 py-4 text-center">Per seat</td>
+              </tr>
+              <tr>
+                <td class="px-6 py-4 font-medium text-gray-900">OKRs and goals</td>
+                <td class="px-6 py-4 text-center text-green-600">Built-in</td>
+                <td class="px-6 py-4 text-center">Add-on</td>
+              </tr>
+              <tr>
+                <td class="px-6 py-4 font-medium text-gray-900">Projects with check-ins</td>
+                <td class="px-6 py-4 text-center text-green-600">Built-in</td>
+                <td class="px-6 py-4 text-center">Custom boards</td>
+              </tr>
+              <tr>
+                <td class="px-6 py-4 font-medium text-gray-900">CLI access</td>
+                <td class="px-6 py-4 text-center text-green-600">Yes</td>
+                <td class="px-6 py-4 text-center text-gray-400">No</td>
+              </tr>
+              <tr>
+                <td class="px-6 py-4 font-medium text-gray-900">API-first design</td>
+                <td class="px-6 py-4 text-center text-green-600">Yes</td>
+                <td class="px-6 py-4 text-center">REST API available</td>
+              </tr>
+              <tr>
+                <td class="px-6 py-4 font-medium text-gray-900">AI agent integration</td>
+                <td class="px-6 py-4 text-center text-green-600">Native</td>
+                <td class="px-6 py-4 text-center">Limited</td>
+              </tr>
+              <tr>
+                <td class="px-6 py-4 font-medium text-gray-900">Visual boards</td>
+                <td class="px-6 py-4 text-center text-gray-400">No</td>
+                <td class="px-6 py-4 text-center text-green-600">Yes</td>
+              </tr>
+              <tr>
+                <td class="px-6 py-4 font-medium text-gray-900">Workflow automations</td>
+                <td class="px-6 py-4 text-center">Minimal</td>
+                <td class="px-6 py-4 text-center text-green-600">Extensive</td>
+              </tr>
+              <tr>
+                <td class="px-6 py-4 font-medium text-gray-900">Enterprise features</td>
+                <td class="px-6 py-4 text-center">Growing</td>
+                <td class="px-6 py-4 text-center text-green-600">Mature</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      {/* When to choose sections */}
+      <div class="mx-auto mt-16 max-w-4xl">
+        <h2 class="text-2xl font-semibold text-gray-900">When to choose Operately</h2>
+        <ul class="mt-6 space-y-3 text-gray-600">
+          <li class="flex items-start gap-3">
+            <svg class="mt-1 h-5 w-5 flex-shrink-0 text-operately-blue" fill="currentColor" viewBox="0 0 20 20">
+              <path fill-rule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clip-rule="evenodd"/>
+            </svg>
+            <span>You want an open source tool you can inspect, modify, and self-host</span>
+          </li>
+          <li class="flex items-start gap-3">
+            <svg class="mt-1 h-5 w-5 flex-shrink-0 text-operately-blue" fill="currentColor" viewBox="0 0 20 20">
+              <path fill-rule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clip-rule="evenodd"/>
+            </svg>
+            <span>Your team runs on goals and OKRs, not just tasks and boards</span>
+          </li>
+          <li class="flex items-start gap-3">
+            <svg class="mt-1 h-5 w-5 flex-shrink-0 text-operately-blue" fill="currentColor" viewBox="0 0 20 20">
+              <path fill-rule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clip-rule="evenodd"/>
+            </svg>
+            <span>You prefer flat-rate pricing over per-seat costs that grow with your team</span>
+          </li>
+          <li class="flex items-start gap-3">
+            <svg class="mt-1 h-5 w-5 flex-shrink-0 text-operately-blue" fill="currentColor" viewBox="0 0 20 20">
+              <path fill-rule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clip-rule="evenodd"/>
+            </svg>
+            <span>You use or plan to use AI agents and want a tool with CLI and API access</span>
+          </li>
+          <li class="flex items-start gap-3">
+            <svg class="mt-1 h-5 w-5 flex-shrink-0 text-operately-blue" fill="currentColor" viewBox="0 0 20 20">
+              <path fill-rule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clip-rule="evenodd"/>
+            </svg>
+            <span>You need infrastructure control or data sovereignty</span>
+          </li>
+        </ul>
+      </div>
+
+      <div class="mx-auto mt-12 max-w-4xl">
+        <h2 class="text-2xl font-semibold text-gray-900">When Monday.com might be better</h2>
+        <ul class="mt-6 space-y-3 text-gray-600">
+          <li class="flex items-start gap-3">
+            <svg class="mt-1 h-5 w-5 flex-shrink-0 text-gray-400" fill="currentColor" viewBox="0 0 20 20">
+              <path fill-rule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clip-rule="evenodd"/>
+            </svg>
+            <span>You need highly visual boards and drag-and-drop workflows</span>
+          </li>
+          <li class="flex items-start gap-3">
+            <svg class="mt-1 h-5 w-5 flex-shrink-0 text-gray-400" fill="currentColor" viewBox="0 0 20 20">
+              <path fill-rule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clip-rule="evenodd"/>
+            </svg>
+            <span>You rely on extensive workflow automations with complex triggers</span>
+          </li>
+          <li class="flex items-start gap-3">
+            <svg class="mt-1 h-5 w-5 flex-shrink-0 text-gray-400" fill="currentColor" viewBox="0 0 20 20">
+              <path fill-rule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clip-rule="evenodd"/>
+            </svg>
+            <span>Your team is large and needs mature enterprise features today</span>
+          </li>
+          <li class="flex items-start gap-3">
+            <svg class="mt-1 h-5 w-5 flex-shrink-0 text-gray-400" fill="currentColor" viewBox="0 0 20 20">
+              <path fill-rule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clip-rule="evenodd"/>
+            </svg>
+            <span>You need integrations with a wide range of third-party tools</span>
+          </li>
+        </ul>
+      </div>
+
+      {/* Philosophy section */}
+      <div class="mx-auto mt-16 max-w-4xl">
+        <h2 class="text-2xl font-semibold text-gray-900">Different philosophies</h2>
+        <div class="mt-6 space-y-4 text-gray-600 leading-7">
+          <p>
+            Monday.com is built around visual boards and flexible workflows. It works well for teams
+            that need to manage many types of work across departments with custom automations.
+          </p>
+          <p>
+            Operately takes a different approach. It is built around goals and projects with structured
+            check-ins, so teams stay focused on outcomes rather than just tracking tasks. It is open source,
+            deployable on your own infrastructure, and designed from the ground up to work with CLI tools
+            and AI agents.
+          </p>
+          <p>
+            The trade-off is clear: Monday.com offers more visual flexibility and a larger feature set today.
+            Operately offers transparency, infrastructure control, no per-seat pricing, and a developer-friendly
+            architecture that treats automation and AI as first-class citizens.
+          </p>
+        </div>
+      </div>
+
+      {/* CTA */}
+      <div class="mx-auto mt-16 max-w-3xl text-center">
+        <h2 class="text-2xl font-semibold text-gray-900">Try Operately</h2>
+        <p class="mt-4 text-gray-600">
+          Start with Operately Cloud for free, or self-host it on your own infrastructure.
+        </p>
+        <div class="mt-8 flex flex-col gap-4 sm:flex-row sm:justify-center">
+          <a
+            href={signUpUrl}
+            class="inline-flex items-center justify-center rounded-md bg-edgy-blue px-5 py-3 text-sm font-semibold text-white shadow-sm hover:bg-operately-dark-blue"
+          >
+            Start free on Cloud
+          </a>
+          <a
+            href="/self-hosted"
+            class="inline-flex items-center justify-center rounded-md border border-gray-300 px-5 py-3 text-sm font-semibold text-gray-900 hover:border-operately-blue hover:text-operately-blue"
+          >
+            Self-host Operately
+          </a>
+        </div>
+      </div>
+    </div>
+  </main>
+</BaseLayout>

--- a/src/pages/vs/monday.astro
+++ b/src/pages/vs/monday.astro
@@ -45,6 +45,26 @@ const signUpUrl = import.meta.env.SIGN_UP_URL;
         </p>
       </div>
 
+      {/* Key differentiators bar */}
+      <div class="mx-auto mt-10 flex max-w-3xl flex-wrap justify-center gap-4">
+        <span class="inline-flex items-center gap-1.5 rounded-full bg-operately-blue-tint-1 px-4 py-1.5 text-sm font-medium text-operately-dark-blue">
+          <svg class="h-4 w-4" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clip-rule="evenodd"/></svg>
+          Open source
+        </span>
+        <span class="inline-flex items-center gap-1.5 rounded-full bg-operately-blue-tint-1 px-4 py-1.5 text-sm font-medium text-operately-dark-blue">
+          <svg class="h-4 w-4" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clip-rule="evenodd"/></svg>
+          Self-hostable
+        </span>
+        <span class="inline-flex items-center gap-1.5 rounded-full bg-operately-blue-tint-1 px-4 py-1.5 text-sm font-medium text-operately-dark-blue">
+          <svg class="h-4 w-4" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clip-rule="evenodd"/></svg>
+          No per-seat pricing
+        </span>
+        <span class="inline-flex items-center gap-1.5 rounded-full bg-operately-blue-tint-1 px-4 py-1.5 text-sm font-medium text-operately-dark-blue">
+          <svg class="h-4 w-4" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clip-rule="evenodd"/></svg>
+          CLI and API first
+        </span>
+      </div>
+
       {/* Quick summary */}
       <div class="mx-auto mt-16 grid max-w-4xl gap-6 sm:grid-cols-2">
         <div class="rounded-2xl border border-gray-200 p-6">
@@ -173,6 +193,17 @@ const signUpUrl = import.meta.env.SIGN_UP_URL;
         </div>
       </div>
 
+      {/* Mid-page CTA */}
+      <div class="mx-auto mt-12 max-w-4xl rounded-xl bg-gray-50 p-6 text-center">
+        <p class="text-sm font-medium text-gray-900">Want to see Operately in action?</p>
+        <a
+          href={signUpUrl}
+          class="mt-3 inline-flex items-center justify-center rounded-md bg-edgy-blue px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-operately-dark-blue"
+        >
+          Try free — no credit card needed
+        </a>
+      </div>
+
       {/* When to choose sections */}
       <div class="mx-auto mt-16 max-w-4xl">
         <h2 class="text-2xl font-semibold text-gray-900">When to choose Operately</h2>
@@ -267,6 +298,7 @@ const signUpUrl = import.meta.env.SIGN_UP_URL;
         <h2 class="text-2xl font-semibold text-gray-900">Try Operately</h2>
         <p class="mt-4 text-gray-600">
           Start with Operately Cloud for free, or self-host it on your own infrastructure.
+          No credit card required.
         </p>
         <div class="mt-8 flex flex-col gap-4 sm:flex-row sm:justify-center">
           <a


### PR DESCRIPTION
## What

Adds two comparison pages:
- `/vs/monday` — targeting "monday.com alternative" (vol 600, KD 1)
- `/vs/asana` — targeting "asana alternative" terms

## Why

From search landscape research (operately/gtm-context#20):
- Operately currently ranks for **zero** product-category keywords
- "monday.com alternative" has 600 monthly searches with almost no competition (KD 1)
- LLMs don't recommend Operately because there's no comparison content anywhere

## Content approach

Honest comparison format:
- Side-by-side summary cards
- Feature comparison table (shows where competitors are better too)
- "When to choose Operately" and "When X might be better" sections
- Different philosophies explanation
- CTA to Cloud signup and self-hosted

Design follows the same patterns as the `/self-hosted` page (same layout, colors, spacing).

## Closes
- operately/gtm-context#27
- operately/gtm-context#28
- Relates to operately/gtm-context#20
