### PR TITLE
Add /for/startups audience page

### DIFF
--- a/src/pages/for/startups.astro
+++ b/src/pages/for/startups.astro
@@ -1,0 +1,210 @@
+---
+import BaseLayout from "../../layouts/BaseLayout.astro";
+
+const pageTitle = "Project Management for Startups";
+const pageDescription =
+  "Operately is project management built for startups: open source, fast to deploy, no per-seat pricing, with goals and projects connected from day one.";
+
+const schema = {
+  "@type": "WebPage",
+  "@id": "https://operately.com/for/startups/#webpage",
+  url: "https://operately.com/for/startups/",
+  name: pageTitle,
+  description: pageDescription,
+  isPartOf: {
+    "@id": "https://operately.com/#website",
+  },
+  about: {
+    "@id": "https://operately.com/#organization",
+  },
+};
+
+const signUpUrl = import.meta.env.SIGN_UP_URL;
+---
+
+<BaseLayout
+  title={pageTitle}
+  description={pageDescription}
+  image="/images/social/card-summary-large.png"
+  twitterCardType="summary_large_image"
+  schema={schema}
+>
+  <main class="bg-white py-8 sm:py-16">
+    <div class="mx-auto max-w-5xl px-6 lg:px-8">
+      {/* Hero */}
+      <div class="mx-auto max-w-3xl text-center">
+        <p class="text-sm font-semibold uppercase tracking-wide text-operately-blue">
+          For Startups
+        </p>
+        <h1 class="mt-3 text-balance text-4xl font-semibold tracking-tight text-gray-900 sm:text-5xl">
+          Project management that grows with your startup
+        </h1>
+        <p class="mt-6 text-lg leading-8 text-gray-600">
+          You do not need Monday.com or Asana at 10 people. You need something lightweight that
+          connects goals to execution without the enterprise overhead. Operately is open source,
+          free to start, and designed for small teams moving fast.
+        </p>
+      </div>
+
+      {/* Key differentiators */}
+      <div class="mx-auto mt-10 flex max-w-3xl flex-wrap justify-center gap-4">
+        <span class="inline-flex items-center gap-1.5 rounded-full bg-operately-blue-tint-1 px-4 py-1.5 text-sm font-medium text-operately-dark-blue">
+          <svg class="h-4 w-4" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clip-rule="evenodd"/></svg>
+          Free to start
+        </span>
+        <span class="inline-flex items-center gap-1.5 rounded-full bg-operately-blue-tint-1 px-4 py-1.5 text-sm font-medium text-operately-dark-blue">
+          <svg class="h-4 w-4" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clip-rule="evenodd"/></svg>
+          No per-seat costs
+        </span>
+        <span class="inline-flex items-center gap-1.5 rounded-full bg-operately-blue-tint-1 px-4 py-1.5 text-sm font-medium text-operately-dark-blue">
+          <svg class="h-4 w-4" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clip-rule="evenodd"/></svg>
+          Open source
+        </span>
+        <span class="inline-flex items-center gap-1.5 rounded-full bg-operately-blue-tint-1 px-4 py-1.5 text-sm font-medium text-operately-dark-blue">
+          <svg class="h-4 w-4" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clip-rule="evenodd"/></svg>
+          Deploy in minutes
+        </span>
+      </div>
+
+      {/* Problem / Solution */}
+      <div class="mx-auto mt-16 max-w-4xl">
+        <h2 class="text-2xl font-semibold text-gray-900">The startup project management problem</h2>
+        <div class="mt-6 space-y-4 text-gray-600 leading-7">
+          <p>
+            Most project management tools are built for enterprises. They come with per-seat pricing
+            that punishes team growth, feature lists designed for 500-person organizations, and setup
+            processes that take longer than your sprint cycle.
+          </p>
+          <p>
+            Startups need something different: a tool that helps a small team stay aligned on goals,
+            ship projects consistently, and keep everyone informed without meetings. Something that
+            costs nothing to start and does not become a budget problem when you hire your 15th person.
+          </p>
+        </div>
+      </div>
+
+      {/* What you get */}
+      <div class="mx-auto mt-16 max-w-4xl">
+        <h2 class="text-2xl font-semibold text-gray-900">What you get with Operately</h2>
+        <div class="mt-8 grid gap-6 sm:grid-cols-2">
+          <div class="rounded-2xl border border-gray-200 p-6">
+            <h3 class="font-semibold text-gray-900">Company goals in one place</h3>
+            <p class="mt-2 text-sm text-gray-600">
+              Set quarterly OKRs or simple goals. Everyone sees what matters and how things are
+              tracking without asking in Slack.
+            </p>
+          </div>
+          <div class="rounded-2xl border border-gray-200 p-6">
+            <h3 class="font-semibold text-gray-900">Projects with built-in check-ins</h3>
+            <p class="mt-2 text-sm text-gray-600">
+              Track projects with regular progress updates. No more "can you send a status update"
+              messages. The structure keeps everyone informed.
+            </p>
+          </div>
+          <div class="rounded-2xl border border-gray-200 p-6">
+            <h3 class="font-semibold text-gray-900">Flat-rate pricing</h3>
+            <p class="mt-2 text-sm text-gray-600">
+              Pay a flat fee regardless of team size. Add people without worrying about your
+              tool bill growing faster than your revenue.
+            </p>
+          </div>
+          <div class="rounded-2xl border border-gray-200 p-6">
+            <h3 class="font-semibold text-gray-900">CLI and API for technical teams</h3>
+            <p class="mt-2 text-sm text-gray-600">
+              Update goals and projects from the terminal. Integrate with your existing dev
+              workflow. Use AI agents to automate check-ins and reporting.
+            </p>
+          </div>
+        </div>
+      </div>
+
+      {/* Mid-page CTA */}
+      <div class="mx-auto mt-12 max-w-4xl rounded-xl bg-gray-50 p-6 text-center">
+        <p class="text-sm font-medium text-gray-900">Set up takes less than 5 minutes</p>
+        <a
+          href={signUpUrl}
+          class="mt-3 inline-flex items-center justify-center rounded-md bg-edgy-blue px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-operately-dark-blue"
+        >
+          Start free — no credit card needed
+        </a>
+      </div>
+
+      {/* Why not enterprise tools */}
+      <div class="mx-auto mt-16 max-w-4xl">
+        <h2 class="text-2xl font-semibold text-gray-900">Why not just use Monday.com or Asana?</h2>
+        <div class="mt-6 space-y-4 text-gray-600 leading-7">
+          <p>
+            They work. But they are designed for a different scale and a different buyer. Here is what
+            matters when you are a startup:
+          </p>
+        </div>
+        <div class="mt-8 overflow-hidden rounded-xl border border-gray-200">
+          <table class="w-full text-sm">
+            <thead>
+              <tr class="border-b border-gray-200 bg-gray-50">
+                <th class="px-6 py-3 text-left font-medium text-gray-500"></th>
+                <th class="px-6 py-3 text-center font-medium text-gray-900">Operately</th>
+                <th class="px-6 py-3 text-center font-medium text-gray-900">Enterprise tools</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-gray-200">
+              <tr>
+                <td class="px-6 py-4 font-medium text-gray-900">Cost at 15 people</td>
+                <td class="px-6 py-4 text-center text-green-600">$0 (free plan)</td>
+                <td class="px-6 py-4 text-center">$135-225/mo</td>
+              </tr>
+              <tr>
+                <td class="px-6 py-4 font-medium text-gray-900">Setup time</td>
+                <td class="px-6 py-4 text-center text-green-600">Minutes</td>
+                <td class="px-6 py-4 text-center">Hours to days</td>
+              </tr>
+              <tr>
+                <td class="px-6 py-4 font-medium text-gray-900">Goals built in</td>
+                <td class="px-6 py-4 text-center text-green-600">Yes, free</td>
+                <td class="px-6 py-4 text-center">Paid add-on or higher tier</td>
+              </tr>
+              <tr>
+                <td class="px-6 py-4 font-medium text-gray-900">Feature bloat</td>
+                <td class="px-6 py-4 text-center text-green-600">Minimal</td>
+                <td class="px-6 py-4 text-center">Significant</td>
+              </tr>
+              <tr>
+                <td class="px-6 py-4 font-medium text-gray-900">Open source</td>
+                <td class="px-6 py-4 text-center text-green-600">Yes</td>
+                <td class="px-6 py-4 text-center text-gray-400">No</td>
+              </tr>
+              <tr>
+                <td class="px-6 py-4 font-medium text-gray-900">Self-host option</td>
+                <td class="px-6 py-4 text-center text-green-600">Yes</td>
+                <td class="px-6 py-4 text-center text-gray-400">No</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      {/* CTA */}
+      <div class="mx-auto mt-16 max-w-3xl text-center">
+        <h2 class="text-2xl font-semibold text-gray-900">Start running your startup on Operately</h2>
+        <p class="mt-4 text-gray-600">
+          Free to start. No per-seat pricing. Deploy in minutes or use the cloud.
+          No credit card required.
+        </p>
+        <div class="mt-8 flex flex-col gap-4 sm:flex-row sm:justify-center">
+          <a
+            href={signUpUrl}
+            class="inline-flex items-center justify-center rounded-md bg-edgy-blue px-5 py-3 text-sm font-semibold text-white shadow-sm hover:bg-operately-dark-blue"
+          >
+            Start free on Cloud
+          </a>
+          <a
+            href="/self-hosted"
+            class="inline-flex items-center justify-center rounded-md border border-gray-300 px-5 py-3 text-sm font-semibold text-gray-900 hover:border-operately-blue hover:text-operately-blue"
+          >
+            Self-host Operately
+          </a>
+        </div>
+      </div>
+    </div>
+  </main>
+</BaseLayout>

--- a/src/pages/for/startups.astro
+++ b/src/pages/for/startups.astro
@@ -37,12 +37,12 @@ const signUpUrl = import.meta.env.SIGN_UP_URL;
           For Startups
         </p>
         <h1 class="mt-3 text-balance text-4xl font-semibold tracking-tight text-gray-900 sm:text-5xl">
-          Project management that grows with your startup
+          Project management that grows with your team
         </h1>
         <p class="mt-6 text-lg leading-8 text-gray-600">
-          You do not need Monday.com or Asana at 10 people. You need something lightweight that
+          Small teams do not need Monday.com or Asana. You need something lightweight that
           connects goals to execution without the enterprise overhead. Operately is open source,
-          free to start, and designed for small teams moving fast.
+          free to start, and designed for teams of 5 to 50 moving fast.
         </p>
       </div>
 
@@ -68,7 +68,7 @@ const signUpUrl = import.meta.env.SIGN_UP_URL;
 
       {/* Problem / Solution */}
       <div class="mx-auto mt-16 max-w-4xl">
-        <h2 class="text-2xl font-semibold text-gray-900">The startup project management problem</h2>
+        <h2 class="text-2xl font-semibold text-gray-900">The small team project management problem</h2>
         <div class="mt-6 space-y-4 text-gray-600 leading-7">
           <p>
             Most project management tools are built for enterprises. They come with per-seat pricing
@@ -76,7 +76,7 @@ const signUpUrl = import.meta.env.SIGN_UP_URL;
             processes that take longer than your sprint cycle.
           </p>
           <p>
-            Startups need something different: a tool that helps a small team stay aligned on goals,
+            Small teams need something different: a tool that helps a growing team stay aligned on goals,
             ship projects consistently, and keep everyone informed without meetings. Something that
             costs nothing to start and does not become a budget problem when you hire your 15th person.
           </p>
@@ -185,7 +185,7 @@ const signUpUrl = import.meta.env.SIGN_UP_URL;
 
       {/* CTA */}
       <div class="mx-auto mt-16 max-w-3xl text-center">
-        <h2 class="text-2xl font-semibold text-gray-900">Start running your startup on Operately</h2>
+        <h2 class="text-2xl font-semibold text-gray-900">Start running your team on Operately</h2>
         <p class="mt-4 text-gray-600">
           Free to start. No per-seat pricing. Deploy in minutes or use the cloud.
           No credit card required.


### PR DESCRIPTION
## What

Adds `/for/startups` page targeting "project management for startups" (vol 300, KD 1).

## Content

- Problem framing: enterprise tools don't fit startups
- Feature cards for startup-relevant capabilities
- Comparison table: Operately vs enterprise tool costs/complexity
- Emphasis on flat pricing, fast setup, open source

## Closes
- operately/gtm-context#30
- Relates to operately/gtm-context#20
