### PR TITLE
Homepage SEO: category keywords in title and meta

### DIFF
--- a/src/pages/_index/HomePage.astro
+++ b/src/pages/_index/HomePage.astro
@@ -1,9 +1,9 @@
 ---
 import BaseLayout from "../../layouts/BaseLayout.astro";
 
-const pageTitle = "Operately: Open Source Goal & Project Management for Startups";
+const pageTitle = "Operately: Open Source OKR and Project Management Software";
 const pageDescription =
-  "Operately helps teams run goals, projects, and weekly execution with built-in workflows. Use Operately Cloud or self-host it in minutes.";
+  "Open source project management with built-in OKR goal tracking. Run goals, projects, and check-ins with structure that keeps your team aligned. Free to start, self-host in minutes.";
 
 import Hero from "./Hero.astro";
 import Intro from "./Intro.astro";


### PR DESCRIPTION
## Homepage SEO optimization (gtm-context#32)

### Changes
- **Title**: `Operately: Open Source OKR and Project Management Software` (was: "...Goal & Project Management for Startups")
- **Meta description**: "Open source project management with built-in OKR goal tracking. Run goals, projects, and check-ins with structure that keeps your team aligned. Free to start, self-host in minutes."

### Why
- Old title said "for Startups" which contradicts current positioning (small teams across all sectors)
- Added "OKR" and "Software" — both high-value category terms we rank for on the /okr-software page but not from homepage
- Meta now includes searchable language instead of generic "built-in workflows"

### What I left alone
- H1 ("Stop burning energy on keeping your teams together") — brand/emotional copy, not the place for keyword stuffing
- Hero subtitle already has "open source system for running goals and projects" — good natural keyword coverage
- Design/layout unchanged

### Expected outcome
GSC should start showing impressions for "okr software", "open source project management", "project management software" within 4-6 weeks.

---
Closes operately/gtm-context#32