### PR TITLE
AI page: factual comparison table

### DIFF
--- a/src/pages/ai.astro
+++ b/src/pages/ai.astro
@@ -178,46 +178,53 @@ operately goals list --space engineering</code></pre>
 
       {/* Comparison */}
       <div class="mx-auto mt-16 max-w-4xl">
-        <h2 class="text-2xl font-semibold text-gray-900">How this compares to "AI features" in other tools</h2>
+        <h2 class="text-2xl font-semibold text-gray-900">Agent-readiness compared</h2>
         <div class="mt-8 overflow-hidden rounded-xl border border-gray-200">
           <table class="w-full text-sm">
             <thead>
               <tr class="border-b border-gray-200 bg-gray-50">
                 <th class="px-6 py-3 text-left font-medium text-gray-500"></th>
                 <th class="px-6 py-3 text-center font-medium text-gray-900">Operately</th>
-                <th class="px-6 py-3 text-center font-medium text-gray-900">Typical PM tools</th>
+                <th class="px-6 py-3 text-center font-medium text-gray-900">Notion</th>
+                <th class="px-6 py-3 text-center font-medium text-gray-900">Monday / Asana</th>
               </tr>
             </thead>
             <tbody class="divide-y divide-gray-200">
               <tr>
-                <td class="px-6 py-4 font-medium text-gray-900">Agent access</td>
-                <td class="px-6 py-4 text-center text-green-600">Full CLI + API</td>
-                <td class="px-6 py-4 text-center">Chat widget or copilot</td>
+                <td class="px-6 py-4 font-medium text-gray-900">CLI</td>
+                <td class="px-6 py-4 text-center text-green-600">Yes</td>
+                <td class="px-6 py-4 text-center text-gray-400">No</td>
+                <td class="px-6 py-4 text-center text-gray-400">No</td>
               </tr>
               <tr>
-                <td class="px-6 py-4 font-medium text-gray-900">What agents can do</td>
-                <td class="px-6 py-4 text-center text-green-600">Everything a human can</td>
-                <td class="px-6 py-4 text-center">Summarize, suggest</td>
+                <td class="px-6 py-4 font-medium text-gray-900">Official agent/MCP tooling</td>
+                <td class="px-6 py-4 text-center text-green-600">Yes (skills)</td>
+                <td class="px-6 py-4 text-center text-green-600">Yes (MCP server)</td>
+                <td class="px-6 py-4 text-center text-gray-400">No</td>
               </tr>
               <tr>
-                <td class="px-6 py-4 font-medium text-gray-900">Works with any agent</td>
-                <td class="px-6 py-4 text-center text-green-600">Yes (CLI/API)</td>
-                <td class="px-6 py-4 text-center text-gray-400">Vendor-locked AI</td>
-              </tr>
-              <tr>
-                <td class="px-6 py-4 font-medium text-gray-900">Data structure</td>
-                <td class="px-6 py-4 text-center text-green-600">Typed + structured</td>
-                <td class="px-6 py-4 text-center">Freeform text</td>
+                <td class="px-6 py-4 font-medium text-gray-900">API</td>
+                <td class="px-6 py-4 text-center text-green-600">Yes</td>
+                <td class="px-6 py-4 text-center text-green-600">Yes</td>
+                <td class="px-6 py-4 text-center text-green-600">Yes</td>
               </tr>
               <tr>
                 <td class="px-6 py-4 font-medium text-gray-900">Open source</td>
                 <td class="px-6 py-4 text-center text-green-600">Yes</td>
+                <td class="px-6 py-4 text-center text-gray-400">No</td>
                 <td class="px-6 py-4 text-center text-gray-400">No</td>
               </tr>
               <tr>
                 <td class="px-6 py-4 font-medium text-gray-900">Self-hostable</td>
                 <td class="px-6 py-4 text-center text-green-600">Yes</td>
                 <td class="px-6 py-4 text-center text-gray-400">No</td>
+                <td class="px-6 py-4 text-center text-gray-400">No</td>
+              </tr>
+              <tr>
+                <td class="px-6 py-4 font-medium text-gray-900">Built-in goals/OKRs</td>
+                <td class="px-6 py-4 text-center text-green-600">Yes</td>
+                <td class="px-6 py-4 text-center text-gray-400">No</td>
+                <td class="px-6 py-4 text-center">Paid add-on</td>
               </tr>
             </tbody>
           </table>


### PR DESCRIPTION
Fix misleading comparison table on /ai page. Old version claimed competitors had 'limited' agent access — factually wrong. New table names specific tools (Notion, Monday, Asana) and compares verified capabilities: CLI (only Operately), official MCP/agent tooling (Operately + Notion), API (everyone), open source, self-host, goals.