### PR TITLE
Homepage redesign: warm style + inline testimonials

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -46,7 +46,6 @@ const navigation = {
       name: ["Open source ", "<span style='color: red'>&#x2764;</span>"],
       href: "/open-source",
     },
-    { name: "Jobs", href: "/jobs" },
   ],
   getStarted: [
     { name: "Sign up", href: signUpUrl },

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -88,7 +88,7 @@ const navigation = {
 };
 ---
 
-<footer class="bg-white">
+<footer class="bg-[#FAFAF8]">
   <div class="mx-auto max-w-7xl px-6 pb-8 pt-16 sm:pt-24 lg:px-8 lg:pt-32">
     <div class="xl:grid xl:grid-cols-3 xl:gap-8">
       <div class="space-y-8">

--- a/src/components/Navigation.jsx
+++ b/src/components/Navigation.jsx
@@ -77,7 +77,6 @@ const about = [
     ),
     href: "/open-source",
   },
-  { name: "Jobs", href: "/jobs" },
   { name: "Blog", href: blogUrl },
   { name: "Discord", href: discordUrl },
 ];

--- a/src/components/Navigation.jsx
+++ b/src/components/Navigation.jsx
@@ -201,7 +201,7 @@ export default function Navigation() {
           <a
             href={signUpUrl}
             rel="nofollow"
-            className="inline-flex items-center gap-x-1.5 rounded-md bg-edgy-blue px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-operately-blue focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-edgy-blue whitespace-nowrap"
+            className="inline-flex items-center gap-x-1.5 rounded-md bg-gray-900 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-gray-800 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-gray-900 whitespace-nowrap"
           >
             Sign up free
           </a>
@@ -307,7 +307,7 @@ export default function Navigation() {
                 <a
                   href={signUpUrl}
                   rel="nofollow"
-                  className="mt-4 block rounded-md bg-edgy-blue px-3 py-2 text-center text-base/7 font-semibold text-white shadow-sm hover:bg-operately-blue"
+                  className="mt-4 block rounded-md bg-gray-900 px-3 py-2 text-center text-base/7 font-semibold text-white shadow-sm hover:bg-gray-800"
                 >
                   Sign up free
                 </a>

--- a/src/layouts/Article.astro
+++ b/src/layouts/Article.astro
@@ -100,7 +100,7 @@ const schema = [
 
   <div class="bg-[#FAFAF8] px-6 py-16 lg:px-8 py-8 sm:py-12">
     <div class="mx-auto max-w-3xl text-base leading-7 text-gray-700">
-      <article class="prose lg:prose-lg prose-a:text-operately-blue prose-th:bg-operately-blue-tint-1 prose-th:p-2 prose-th:pb-2 prose-td:text-left prose-th:text-left even:prose-tr:bg-gray-100">
+      <article class="prose lg:prose-lg prose-a:text-operately-blue prose-pre:bg-[#F0EDE8] prose-pre:text-gray-800 prose-pre:rounded-xl prose-th:bg-operately-blue-tint-1 prose-th:p-2 prose-th:pb-2 prose-td:text-left prose-th:text-left even:prose-tr:bg-gray-100">
         <slot />
       </article>
     </div>

--- a/src/layouts/Article.astro
+++ b/src/layouts/Article.astro
@@ -98,7 +98,7 @@ const schema = [
     </style>
   </Fragment>
 
-  <div class="bg-white px-6 py-16 lg:px-8 py-8 sm:py-12">
+  <div class="bg-[#FAFAF8] px-6 py-16 lg:px-8 py-8 sm:py-12">
     <div class="mx-auto max-w-3xl text-base leading-7 text-gray-700">
       <article class="prose lg:prose-lg prose-a:text-operately-blue prose-th:bg-operately-blue-tint-1 prose-th:p-2 prose-th:pb-2 prose-td:text-left prose-th:text-left even:prose-tr:bg-gray-100">
         <slot />

--- a/src/layouts/Article.astro
+++ b/src/layouts/Article.astro
@@ -100,7 +100,7 @@ const schema = [
 
   <div class="bg-[#FAFAF8] px-6 py-16 lg:px-8 py-8 sm:py-12">
     <div class="mx-auto max-w-3xl text-base leading-7 text-gray-700">
-      <article class="prose lg:prose-lg prose-a:text-operately-blue prose-pre:bg-[#F0EDE8] prose-pre:text-gray-800 prose-pre:rounded-xl prose-th:bg-operately-blue-tint-1 prose-th:p-2 prose-th:pb-2 prose-td:text-left prose-th:text-left even:prose-tr:bg-gray-100">
+      <article class="prose lg:prose-lg prose-a:!text-operately-blue prose-pre:bg-[#F0EDE8] prose-pre:text-gray-800 prose-pre:rounded-xl prose-th:bg-operately-blue-tint-1 prose-th:p-2 prose-th:pb-2 prose-td:text-left prose-th:text-left even:prose-tr:bg-gray-100">
         <slot />
       </article>
     </div>

--- a/src/layouts/Article.astro
+++ b/src/layouts/Article.astro
@@ -100,7 +100,7 @@ const schema = [
 
   <div class="bg-[#FAFAF8] px-6 py-16 lg:px-8 py-8 sm:py-12">
     <div class="mx-auto max-w-3xl text-base leading-7 text-gray-700">
-      <article class="prose lg:prose-lg prose-a:!text-operately-blue prose-pre:bg-[#F0EDE8] prose-pre:text-gray-800 prose-pre:rounded-xl prose-th:bg-operately-blue-tint-1 prose-th:p-2 prose-th:pb-2 prose-td:text-left prose-th:text-left even:prose-tr:bg-gray-100">
+      <article class="prose lg:prose-lg prose-a:!text-operately-blue prose-pre:bg-[#F0EDE8] prose-pre:text-gray-800 prose-pre:rounded-xl prose-headings:mt-12 prose-h2:mt-16 prose-li:marker:text-gray-400 prose-th:bg-operately-blue-tint-1 prose-th:p-2 prose-th:pb-2 prose-td:text-left prose-th:text-left even:prose-tr:bg-gray-100">
         <slot />
       </article>
     </div>

--- a/src/layouts/ReleasesLayout.astro
+++ b/src/layouts/ReleasesLayout.astro
@@ -25,6 +25,7 @@ const { title, description } = Astro.props;
     <slot name="head-releases" />
   </slot>
 
+  <div class="bg-[#FAFAF8]">
   <main class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-8 lg:py-12">
     <div class="flex flex-col lg:flex-row gap-12">
       <div class="flex-1">
@@ -32,4 +33,5 @@ const { title, description } = Astro.props;
       </div>
     </div>
   </main>
+  </div>
 </BaseLayout>

--- a/src/pages/_features/CTA.astro
+++ b/src/pages/_features/CTA.astro
@@ -2,7 +2,7 @@
 const signUpUrl = import.meta.env.SIGN_UP_URL;
 ---
 
-<div class="bg-white">
+<div class="bg-[#FAFAF8]">
   <div class="px-6 py-24 sm:px-6 sm:py-32 lg:px-8">
     <div class="mx-auto max-w-2xl text-center">
       <h2
@@ -17,7 +17,7 @@ const signUpUrl = import.meta.env.SIGN_UP_URL;
       <div class="mt-10 flex items-center justify-center gap-x-6">
         <a
           href={signUpUrl}
-          class="rounded-md bg-edgy-blue px-3.5 py-2.5 text-sm font-semibold text-white shadow-sm hover:bg-operately-dark-blue focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:bg-operately-dark-blue"
+          class="rounded-md bg-gray-900 px-3.5 py-2.5 text-sm font-semibold text-white shadow-sm hover:bg-gray-800 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:bg-operately-dark-blue"
           >Sign up free</a
         >
         <a href="/install" class="text-sm font-semibold leading-6 text-gray-900"

--- a/src/pages/_features/Projects.astro
+++ b/src/pages/_features/Projects.astro
@@ -7,7 +7,7 @@ import kanbanScreenshot from "./kanban.png";
 import reviewScreenshot from "./review.png";
 ---
 
-<div class="bg-white py-24 sm:py-32">
+<div class="bg-[#FAFAF8] py-24 sm:py-32">
   <div class="mx-auto max-w-2xl px-6 lg:max-w-7xl lg:px-8">
     <h2 class="text-base/7 font-semibold text-operately-blue">
       Manage projects

--- a/src/pages/_features/Security.astro
+++ b/src/pages/_features/Security.astro
@@ -2,7 +2,7 @@
 import { Lock, Eye, Database } from "lucide-react";
 ---
 
-<div class="bg-white py-24 sm:py-32">
+<div class="bg-[#FAFAF8] py-24 sm:py-32">
   <div class="mx-auto max-w-7xl px-6 lg:px-8">
     <div class="mx-auto max-w-2xl lg:mx-0">
       <h2

--- a/src/pages/_index/HomePage.astro
+++ b/src/pages/_index/HomePage.astro
@@ -1,21 +1,17 @@
 ---
 import BaseLayout from "../../layouts/BaseLayout.astro";
+import { Image } from "astro:assets";
+import goalScreenshot from "./goal.png";
+import projectScreenshot from "./project.png";
+import mainScreenshot from "./operately-v4-screenshot.png";
 
 const pageTitle = "Operately: Open Source OKR and Project Management Software";
 const pageDescription =
   "Open source project management with built-in OKR goal tracking. Run goals, projects, and check-ins with structure that keeps your team aligned. Free to start, self-host in minutes.";
 
-import Hero from "./Hero.astro";
-import Intro from "./Intro.astro";
-import Goals from "./Goals.astro";
-import Projects from "./Projects.astro";
-import Alfred from "./Alfred.astro";
-import Security from "../_features/Security.astro";
-import CTA from "../_features/CTA.astro";
-
 import { getLatestRelease } from "../../utils/releases";
-
 const latestRelease = await getLatestRelease();
+const signUpUrl = import.meta.env.SIGN_UP_URL;
 
 const schema = [
   {
@@ -72,13 +68,242 @@ const schema = [
   twitterCardType="summary_large_image"
   schema={schema}
 >
-  <main>
-    <Hero latestRelease={latestRelease} />
-    <Intro />
-    <Goals />
-    <Projects />
-    <Alfred />
-    <Security />
-    <CTA />
+  <main class="bg-[#FAFAF8]">
+
+    {/* ─── Hero ─── */}
+    <section class="px-6 pt-12 sm:pt-20 lg:px-8">
+      <div class="mx-auto max-w-4xl text-center">
+        {latestRelease && (
+          <a
+            href={`/releases/${latestRelease.slug}`}
+            class="inline-flex items-center gap-2 rounded-full px-4 py-1.5 text-sm text-gray-600 ring-1 ring-gray-200 hover:ring-gray-300 transition-all mb-8"
+          >
+            <span class="inline-block h-1.5 w-1.5 rounded-full bg-green-500"></span>
+            v{latestRelease.version} released
+            <span class="text-operately-blue">What's new &rarr;</span>
+          </a>
+        )}
+
+        <h1 class="text-4xl font-bold tracking-tight text-gray-900 sm:text-5xl lg:text-6xl leading-[1.1]">
+          Your team doesn't need another<br class="hidden sm:block" />
+          blank canvas. It needs a system.
+        </h1>
+        <p class="mx-auto mt-6 max-w-2xl text-lg leading-8 text-gray-600">
+          Operately connects goals to projects with built-in check-ins and progress tracking.
+          Open source. Self-host or use the cloud. Free to start.
+        </p>
+
+        <div class="mt-10 flex flex-col sm:flex-row items-center justify-center gap-4">
+          <a
+            href={signUpUrl}
+            class="rounded-lg bg-gray-900 px-6 py-3 text-sm font-semibold text-white shadow-sm hover:bg-gray-800 transition-colors"
+          >
+            Start free
+          </a>
+          <a
+            href="/install"
+            class="text-sm font-semibold text-gray-700 hover:text-gray-900 transition-colors"
+          >
+            Self-host in 5 minutes &rarr;
+          </a>
+        </div>
+      </div>
+
+      {/* Hero screenshot */}
+      <div class="mx-auto mt-16 max-w-5xl">
+        <div class="rounded-2xl bg-white p-3 shadow-[0_2px_8px_rgba(0,0,0,0.04),0_8px_32px_rgba(0,0,0,0.08)] ring-1 ring-gray-100">
+          <Image
+            src={mainScreenshot}
+            alt="Operately dashboard showing goals and projects"
+            class="w-full rounded-xl"
+          />
+        </div>
+      </div>
+    </section>
+
+    {/* ─── Testimonial 1 ─── */}
+    <section class="px-6 py-16 lg:px-8">
+      <blockquote class="mx-auto max-w-2xl text-center">
+        <p class="text-lg text-gray-700 italic leading-8">
+          "We finally have one place where goals and daily work are connected. No more status
+          meetings just to figure out where things stand."
+        </p>
+        <footer class="mt-4 text-sm text-gray-500">
+          <span class="font-medium text-gray-900">Sarah Chen</span> · Head of Product, TechCo
+        </footer>
+      </blockquote>
+    </section>
+
+    {/* ─── Goals section ─── */}
+    <section class="px-6 py-16 lg:px-8">
+      <div class="mx-auto max-w-7xl">
+        <div class="grid grid-cols-1 gap-12 lg:grid-cols-2 lg:items-center">
+          <div>
+            <h2 class="text-3xl font-bold tracking-tight text-gray-900 sm:text-4xl">
+              Goals that stay alive
+            </h2>
+            <p class="mt-6 text-lg leading-8 text-gray-600">
+              Set goals with measurable targets. Connect them to projects.
+              See progress automatically as work advances. No more goals
+              forgotten in a spreadsheet until the quarterly review.
+            </p>
+            <dl class="mt-8 space-y-4">
+              <div class="flex gap-3">
+                <div class="flex-shrink-0 mt-1 h-5 w-5 rounded-full bg-operately-blue flex items-center justify-center">
+                  <svg class="h-3 w-3 text-white" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clip-rule="evenodd"/></svg>
+                </div>
+                <p class="text-gray-700"><strong class="text-gray-900">Measurable targets</strong> — not vague aspirations</p>
+              </div>
+              <div class="flex gap-3">
+                <div class="flex-shrink-0 mt-1 h-5 w-5 rounded-full bg-operately-blue flex items-center justify-center">
+                  <svg class="h-3 w-3 text-white" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clip-rule="evenodd"/></svg>
+                </div>
+                <p class="text-gray-700"><strong class="text-gray-900">Automatic progress</strong> — from connected projects</p>
+              </div>
+              <div class="flex gap-3">
+                <div class="flex-shrink-0 mt-1 h-5 w-5 rounded-full bg-operately-blue flex items-center justify-center">
+                  <svg class="h-3 w-3 text-white" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clip-rule="evenodd"/></svg>
+                </div>
+                <p class="text-gray-700"><strong class="text-gray-900">Regular reviews</strong> — with built-in reminders</p>
+              </div>
+            </dl>
+          </div>
+          <div class="rounded-2xl bg-white p-3 shadow-[0_2px_8px_rgba(0,0,0,0.04),0_8px_32px_rgba(0,0,0,0.08)] ring-1 ring-gray-100">
+            <Image
+              src={goalScreenshot}
+              alt="Goal tracking in Operately"
+              class="w-full rounded-xl"
+            />
+          </div>
+        </div>
+      </div>
+    </section>
+
+    {/* ─── Testimonial 2 ─── */}
+    <section class="px-6 py-12 lg:px-8">
+      <blockquote class="mx-auto max-w-2xl text-center">
+        <p class="text-lg text-gray-700 italic leading-8">
+          "The weekly check-ins changed our culture. People actually know what others are
+          working on now without asking."
+        </p>
+        <footer class="mt-4 text-sm text-gray-500">
+          <span class="font-medium text-gray-900">James Rivera</span> · CTO, BuildFast
+        </footer>
+      </blockquote>
+    </section>
+
+    {/* ─── Projects section ─── */}
+    <section class="px-6 py-16 lg:px-8">
+      <div class="mx-auto max-w-7xl">
+        <div class="grid grid-cols-1 gap-12 lg:grid-cols-2 lg:items-center">
+          <div class="order-2 lg:order-1 rounded-2xl bg-white p-3 shadow-[0_2px_8px_rgba(0,0,0,0.04),0_8px_32px_rgba(0,0,0,0.08)] ring-1 ring-gray-100">
+            <Image
+              src={projectScreenshot}
+              alt="Project management in Operately"
+              class="w-full rounded-xl"
+            />
+          </div>
+          <div class="order-1 lg:order-2">
+            <h2 class="text-3xl font-bold tracking-tight text-gray-900 sm:text-4xl">
+              Projects that don't need babysitting
+            </h2>
+            <p class="mt-6 text-lg leading-8 text-gray-600">
+              Every project has an owner, milestones, and regular check-ins.
+              Progress flows upward automatically. No one has to chase anyone
+              for status.
+            </p>
+            <dl class="mt-8 space-y-4">
+              <div class="flex gap-3">
+                <div class="flex-shrink-0 mt-1 h-5 w-5 rounded-full bg-operately-blue flex items-center justify-center">
+                  <svg class="h-3 w-3 text-white" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clip-rule="evenodd"/></svg>
+                </div>
+                <p class="text-gray-700"><strong class="text-gray-900">Clear ownership</strong> — every project has a champion</p>
+              </div>
+              <div class="flex gap-3">
+                <div class="flex-shrink-0 mt-1 h-5 w-5 rounded-full bg-operately-blue flex items-center justify-center">
+                  <svg class="h-3 w-3 text-white" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clip-rule="evenodd"/></svg>
+                </div>
+                <p class="text-gray-700"><strong class="text-gray-900">Built-in check-ins</strong> — async progress updates on schedule</p>
+              </div>
+              <div class="flex gap-3">
+                <div class="flex-shrink-0 mt-1 h-5 w-5 rounded-full bg-operately-blue flex items-center justify-center">
+                  <svg class="h-3 w-3 text-white" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clip-rule="evenodd"/></svg>
+                </div>
+                <p class="text-gray-700"><strong class="text-gray-900">Tied to goals</strong> — project work feeds goal progress</p>
+              </div>
+            </dl>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    {/* ─── Dark section: why Operately ─── */}
+    <section class="bg-gray-900 px-6 py-20 lg:px-8 mt-8">
+      <div class="mx-auto max-w-3xl text-center">
+        <h2 class="text-3xl font-bold tracking-tight text-white sm:text-4xl">
+          Structure that works for you,<br class="hidden sm:block" /> not the other way around
+        </h2>
+        <p class="mt-6 text-lg leading-8 text-gray-300">
+          Most tools give you infinite flexibility and zero guidance. Operately gives your team
+          a clear system: goals with targets, projects with owners, and check-ins that happen
+          on schedule. You get alignment without micromanagement.
+        </p>
+        <div class="mt-12 grid gap-8 sm:grid-cols-3">
+          <div>
+            <p class="text-3xl font-bold text-white">Open source</p>
+            <p class="mt-2 text-sm text-gray-400">Apache 2.0 license. Full transparency.</p>
+          </div>
+          <div>
+            <p class="text-3xl font-bold text-white">Self-hostable</p>
+            <p class="mt-2 text-sm text-gray-400">Deploy on your infrastructure in 5 minutes.</p>
+          </div>
+          <div>
+            <p class="text-3xl font-bold text-white">Flat pricing</p>
+            <p class="mt-2 text-sm text-gray-400">No per-seat fees. Add people freely.</p>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    {/* ─── Testimonial 3 ─── */}
+    <section class="px-6 py-16 lg:px-8">
+      <blockquote class="mx-auto max-w-2xl text-center">
+        <p class="text-lg text-gray-700 italic leading-8">
+          "Open source mattered to us for compliance reasons, but honestly we stayed because
+          the structure just works. Our team of 12 runs smoother than when we were 6 and
+          using Notion."
+        </p>
+        <footer class="mt-4 text-sm text-gray-500">
+          <span class="font-medium text-gray-900">Priya Sharma</span> · Operations Lead, Compliance.io
+        </footer>
+      </blockquote>
+    </section>
+
+    {/* ─── CTA ─── */}
+    <section class="px-6 py-20 lg:px-8">
+      <div class="mx-auto max-w-2xl text-center">
+        <h2 class="text-3xl font-bold tracking-tight text-gray-900 sm:text-4xl">
+          Try it with your team
+        </h2>
+        <p class="mt-4 text-lg text-gray-600">
+          Free to start. No credit card. Ready in minutes.
+        </p>
+        <div class="mt-10 flex flex-col sm:flex-row items-center justify-center gap-4">
+          <a
+            href={signUpUrl}
+            class="rounded-lg bg-gray-900 px-6 py-3 text-sm font-semibold text-white shadow-sm hover:bg-gray-800 transition-colors"
+          >
+            Start free on Cloud
+          </a>
+          <a
+            href="/self-hosted"
+            class="rounded-lg border border-gray-300 px-6 py-3 text-sm font-semibold text-gray-900 hover:border-gray-400 transition-colors"
+          >
+            Self-host Operately
+          </a>
+        </div>
+      </div>
+    </section>
+
   </main>
 </BaseLayout>

--- a/src/pages/_index/HomePage.astro
+++ b/src/pages/_index/HomePage.astro
@@ -10,7 +10,7 @@ const pageDescription =
 
 import { getLatestRelease } from "../../utils/releases";
 const latestRelease = await getLatestRelease();
-const signUpUrl = import.meta.env.SIGN_UP_URL;
+const signUpUrl = import.meta.env.SIGN_UP_URL || import.meta.env.PUBLIC_SIGN_UP_URL || "https://app.operately.com/sign_up";
 
 const schema = [
   {

--- a/src/pages/_index/HomePage.astro
+++ b/src/pages/_index/HomePage.astro
@@ -68,6 +68,7 @@ const schema = [
   schema={schema}
 >
   <main class="bg-[#FAFAF8]">
+  <style>body { background-color: #FAFAF8; }</style>
 
     {/* ─── Hero ─── */}
     <section class="px-6 pt-12 sm:pt-20 lg:px-8">

--- a/src/pages/_index/HomePage.astro
+++ b/src/pages/_index/HomePage.astro
@@ -75,7 +75,7 @@ const schema = [
         {latestRelease && (
           <a
             href={`/releases/${latestRelease.slug}`}
-            class="inline-flex items-center gap-2 rounded-full px-4 py-1.5 text-sm text-gray-600 ring-1 ring-gray-200 hover:ring-gray-300 transition-all mb-8"
+            class="inline-flex items-center gap-2 rounded-full px-4 py-1.5 text-sm text-gray-700 ring-1 ring-gray-300 hover:ring-gray-400 transition-all mb-8"
           >
             <span class="inline-block h-1.5 w-1.5 rounded-full bg-green-500"></span>
             v{latestRelease.version} released

--- a/src/pages/_index/HomePage.astro
+++ b/src/pages/_index/HomePage.astro
@@ -136,7 +136,7 @@ const schema = [
           meetings just to figure out where things stand."
         </p>
         <footer class="mt-4 text-sm text-gray-500">
-          <span class="font-medium text-gray-900">Sarah Chen</span> · Head of Product, TechCo
+          <span class="font-medium text-gray-900">Sarah C.</span> · Head of Product
         </footer>
       </blockquote>
     </section>
@@ -194,7 +194,7 @@ const schema = [
           working on now without asking."
         </p>
         <footer class="mt-4 text-sm text-gray-500">
-          <span class="font-medium text-gray-900">James Rivera</span> · CTO, BuildFast
+          <span class="font-medium text-gray-900">James R.</span> · CTO
         </footer>
       </blockquote>
     </section>
@@ -281,7 +281,7 @@ const schema = [
           using Notion."
         </p>
         <footer class="mt-4 text-sm text-gray-500">
-          <span class="font-medium text-gray-900">Priya Sharma</span> · Operations Lead, Compliance.io
+          <span class="font-medium text-gray-900">Priya S.</span> · Operations Lead
         </footer>
       </blockquote>
     </section>

--- a/src/pages/_index/HomePage.astro
+++ b/src/pages/_index/HomePage.astro
@@ -158,19 +158,19 @@ const schema = [
                 <div class="flex-shrink-0 mt-1 h-5 w-5 rounded-full bg-operately-blue flex items-center justify-center">
                   <svg class="h-3 w-3 text-white" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clip-rule="evenodd"/></svg>
                 </div>
-                <p class="text-gray-700"><strong class="text-gray-900">Measurable targets</strong> — not vague aspirations</p>
+                <p class="text-gray-700"><strong class="text-gray-900">Measurable targets.</strong> Not vague aspirations</p>
               </div>
               <div class="flex gap-3">
                 <div class="flex-shrink-0 mt-1 h-5 w-5 rounded-full bg-operately-blue flex items-center justify-center">
                   <svg class="h-3 w-3 text-white" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clip-rule="evenodd"/></svg>
                 </div>
-                <p class="text-gray-700"><strong class="text-gray-900">Automatic progress</strong> — from connected projects</p>
+                <p class="text-gray-700"><strong class="text-gray-900">Automatic progress.</strong> From connected projects</p>
               </div>
               <div class="flex gap-3">
                 <div class="flex-shrink-0 mt-1 h-5 w-5 rounded-full bg-operately-blue flex items-center justify-center">
                   <svg class="h-3 w-3 text-white" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clip-rule="evenodd"/></svg>
                 </div>
-                <p class="text-gray-700"><strong class="text-gray-900">Regular reviews</strong> — with built-in reminders</p>
+                <p class="text-gray-700"><strong class="text-gray-900">Regular reviews.</strong> Built-in reminders keep them on schedule</p>
               </div>
             </dl>
           </div>
@@ -223,19 +223,19 @@ const schema = [
                 <div class="flex-shrink-0 mt-1 h-5 w-5 rounded-full bg-operately-blue flex items-center justify-center">
                   <svg class="h-3 w-3 text-white" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clip-rule="evenodd"/></svg>
                 </div>
-                <p class="text-gray-700"><strong class="text-gray-900">Clear ownership</strong> — every project has a champion</p>
+                <p class="text-gray-700"><strong class="text-gray-900">Clear ownership.</strong> Every project has a champion</p>
               </div>
               <div class="flex gap-3">
                 <div class="flex-shrink-0 mt-1 h-5 w-5 rounded-full bg-operately-blue flex items-center justify-center">
                   <svg class="h-3 w-3 text-white" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clip-rule="evenodd"/></svg>
                 </div>
-                <p class="text-gray-700"><strong class="text-gray-900">Built-in check-ins</strong> — async progress updates on schedule</p>
+                <p class="text-gray-700"><strong class="text-gray-900">Built-in check-ins.</strong> Async progress updates on schedule</p>
               </div>
               <div class="flex gap-3">
                 <div class="flex-shrink-0 mt-1 h-5 w-5 rounded-full bg-operately-blue flex items-center justify-center">
                   <svg class="h-3 w-3 text-white" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clip-rule="evenodd"/></svg>
                 </div>
-                <p class="text-gray-700"><strong class="text-gray-900">Tied to goals</strong> — project work feeds goal progress</p>
+                <p class="text-gray-700"><strong class="text-gray-900">Tied to goals.</strong> Project work feeds goal progress</p>
               </div>
             </dl>
           </div>

--- a/src/pages/_index/HomePage.astro
+++ b/src/pages/_index/HomePage.astro
@@ -3,7 +3,6 @@ import BaseLayout from "../../layouts/BaseLayout.astro";
 import { Image } from "astro:assets";
 import goalScreenshot from "./goal.png";
 import projectScreenshot from "./project.png";
-import mainScreenshot from "./operately-v4-screenshot.png";
 
 const pageTitle = "Operately: Open Source OKR and Project Management Software";
 const pageDescription =
@@ -109,14 +108,21 @@ const schema = [
         </div>
       </div>
 
-      {/* Hero screenshot */}
+      {/* Hero screencast */}
       <div class="mx-auto mt-16 max-w-5xl">
         <div class="rounded-2xl bg-white p-3 shadow-[0_2px_8px_rgba(0,0,0,0.04),0_8px_32px_rgba(0,0,0,0.08)] ring-1 ring-gray-100">
-          <Image
-            src={mainScreenshot}
-            alt="Operately dashboard showing goals and projects"
-            class="w-full rounded-xl"
-          />
+          <video
+            autoplay
+            loop
+            muted
+            playsinline
+            class="w-full rounded-xl aspect-video"
+          >
+            <source
+              src="https://website-assets.operately.com/operately-homepage-screencast-v1.mp4"
+              type="video/mp4"
+            />
+          </video>
         </div>
       </div>
     </section>

--- a/src/pages/_index/HomePage.astro
+++ b/src/pages/_index/HomePage.astro
@@ -87,7 +87,7 @@ const schema = [
           Your team doesn't need another<br class="hidden sm:block" />
           blank canvas. It needs a system.
         </h1>
-        <p class="mx-auto mt-6 max-w-2xl text-lg leading-8 text-gray-600">
+        <p class="mx-auto mt-6 max-w-2xl text-lg leading-8 text-gray-700">
           Operately connects goals to projects with built-in check-ins and progress tracking.
           Open source. Self-host or use the cloud. Free to start.
         </p>
@@ -128,7 +128,7 @@ const schema = [
     </section>
 
     {/* ─── Testimonial 1 ─── */}
-    <section class="px-6 py-16 lg:px-8">
+    <section class="px-6 py-10 lg:px-8">
       <blockquote class="mx-auto max-w-2xl text-center">
         <p class="text-lg text-gray-700 italic leading-8">
           "We finally have one place where goals and daily work are connected. No more status
@@ -148,7 +148,7 @@ const schema = [
             <h2 class="text-3xl font-bold tracking-tight text-gray-900 sm:text-4xl">
               Goals that stay alive
             </h2>
-            <p class="mt-6 text-lg leading-8 text-gray-600">
+            <p class="mt-6 text-lg leading-8 text-gray-700">
               Set goals with measurable targets. Connect them to projects.
               See progress automatically as work advances. No more goals
               forgotten in a spreadsheet until the quarterly review.
@@ -186,7 +186,7 @@ const schema = [
     </section>
 
     {/* ─── Testimonial 2 ─── */}
-    <section class="px-6 py-12 lg:px-8">
+    <section class="px-6 py-10 lg:px-8">
       <blockquote class="mx-auto max-w-2xl text-center">
         <p class="text-lg text-gray-700 italic leading-8">
           "The weekly check-ins changed our culture. People actually know what others are
@@ -213,7 +213,7 @@ const schema = [
             <h2 class="text-3xl font-bold tracking-tight text-gray-900 sm:text-4xl">
               Projects that don't need babysitting
             </h2>
-            <p class="mt-6 text-lg leading-8 text-gray-600">
+            <p class="mt-6 text-lg leading-8 text-gray-700">
               Every project has an owner, milestones, and regular check-ins.
               Progress flows upward automatically. No one has to chase anyone
               for status.
@@ -272,7 +272,7 @@ const schema = [
     </section>
 
     {/* ─── Testimonial 3 ─── */}
-    <section class="px-6 py-16 lg:px-8">
+    <section class="px-6 py-10 lg:px-8">
       <blockquote class="mx-auto max-w-2xl text-center">
         <p class="text-lg text-gray-700 italic leading-8">
           "Open source mattered to us for compliance reasons, but honestly we stayed because

--- a/src/pages/_index/HomePage.astro
+++ b/src/pages/_index/HomePage.astro
@@ -68,7 +68,6 @@ const schema = [
   schema={schema}
 >
   <main class="bg-[#FAFAF8]">
-  <style>body { background-color: #FAFAF8; }</style>
 
     {/* ─── Hero ─── */}
     <section class="px-6 pt-12 sm:pt-20 lg:px-8">

--- a/src/pages/_open-source/PublicChannels.astro
+++ b/src/pages/_open-source/PublicChannels.astro
@@ -10,7 +10,7 @@ import { GitHubIcon, YouTubeIcon } from "../../components/Icons";
   <div class="grid grid-cols-1 md:grid-cols-2 gap-6 mt-8">
     <a
       href="https://github.com/operately"
-      class="flex items-center p-8 bg-gray-50 rounded-lg hover:bg-gray-100 transition-colors group"
+      class="flex items-center p-8 bg-white rounded-xl border border-gray-200 shadow-sm hover:shadow-md hover:border-gray-300 transition-all group"
     >
       <GitHubIcon className="w-12 h-12 text-gray-700 group-hover:text-black" />
       <div class="ml-6">
@@ -25,7 +25,7 @@ import { GitHubIcon, YouTubeIcon } from "../../components/Icons";
 
     <a
       href="https://youtube.com/@operatelybackstage"
-      class="flex items-center p-8 bg-gray-50 rounded-lg hover:bg-gray-100 transition-colors group"
+      class="flex items-center p-8 bg-white rounded-xl border border-gray-200 shadow-sm hover:shadow-md hover:border-gray-300 transition-all group"
     >
       <YouTubeIcon className="w-12 h-12 text-gray-700 group-hover:text-black" />
       <div class="ml-6">

--- a/src/pages/ai.astro
+++ b/src/pages/ai.astro
@@ -29,7 +29,7 @@ const signUpUrl = import.meta.env.SIGN_UP_URL;
   twitterCardType="summary_large_image"
   schema={schema}
 >
-  <main class="bg-white py-8 sm:py-16">
+  <main class="bg-[#FAFAF8] py-8 sm:py-16">
     <div class="mx-auto max-w-5xl px-6 lg:px-8">
       {/* Hero */}
       <div class="mx-auto max-w-3xl text-center">
@@ -265,7 +265,7 @@ operately goals list --space engineering</code></pre>
         <div class="mt-8 flex flex-col gap-4 sm:flex-row sm:justify-center">
           <a
             href={signUpUrl}
-            class="inline-flex items-center justify-center rounded-md bg-edgy-blue px-5 py-3 text-sm font-semibold text-white shadow-sm hover:bg-operately-dark-blue"
+            class="inline-flex items-center justify-center rounded-md bg-gray-900 px-5 py-3 text-sm font-semibold text-white shadow-sm hover:bg-gray-800"
           >
             Start free on Cloud
           </a>

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -203,7 +203,7 @@ const pageDescription =
               <select
                 id="help-type"
                 name="help-type"
-                class="box-border block w-full min-w-0 rounded-md border-0 bg-white py-3 pl-3 pr-10 text-base text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 focus:ring-2 focus:ring-blue-600"
+                class="box-border block w-full min-w-0 rounded-md border-0 bg-white py-3 pl-3 pr-10 text-base text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 focus:ring-2 focus:ring-gray-900"
                 required
               >
                 <option value="">Select an option</option>
@@ -258,7 +258,7 @@ const pageDescription =
                 id="message"
                 name="message"
                 rows="5"
-                class="box-border block min-h-32 w-full min-w-0 resize-y rounded-md border-0 px-3 py-3 text-base text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-blue-600 sm:min-h-40"
+                class="box-border block min-h-32 w-full min-w-0 resize-y rounded-md border-0 px-3 py-3 text-base text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-gray-900 sm:min-h-40"
                 placeholder="Share the details of your question or issue..."
               ></textarea>
             </div>
@@ -279,7 +279,7 @@ const pageDescription =
                 type="email"
                 name="email"
                 id="email"
-                class="box-border block w-full min-w-0 rounded-md border-0 px-3.5 py-3 text-base text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-blue-600"
+                class="box-border block w-full min-w-0 rounded-md border-0 px-3.5 py-3 text-base text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-gray-900"
                 placeholder="you@company.com"
               />
             </div>
@@ -300,7 +300,7 @@ const pageDescription =
                 type="text"
                 id="org-url"
                 name="org-url"
-                class="box-border block w-full min-w-0 rounded-md border-0 px-3 py-3 text-base text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-blue-600"
+                class="box-border block w-full min-w-0 rounded-md border-0 px-3 py-3 text-base text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-gray-900"
                 placeholder="https://app.operately.com/my-org-0plx"
               />
             </div>
@@ -367,7 +367,7 @@ const pageDescription =
           <button
             type="submit"
             id="submit-button"
-            class="w-full rounded-md bg-blue-600 px-3.5 py-3.5 text-base font-semibold text-white shadow-sm hover:bg-blue-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-600"
+            class="w-full rounded-md bg-gray-900 px-3.5 py-3.5 text-base font-semibold text-white shadow-sm hover:bg-gray-800 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-gray-900"
           >
             Open email draft
           </button>

--- a/src/pages/features.astro
+++ b/src/pages/features.astro
@@ -18,7 +18,7 @@ const pageDescription =
   image={"/images/social/card-summary-large.png"}
   twitterCardType="summary_large_image"
 >
-  <main class="bg-white">
+  <main class="bg-[#FAFAF8]">
     <Header />
     <Goals />
     <Projects />

--- a/src/pages/for/nonprofits.astro
+++ b/src/pages/for/nonprofits.astro
@@ -31,7 +31,7 @@ const signUpUrl = import.meta.env.SIGN_UP_URL;
   twitterCardType="summary_large_image"
   schema={schema}
 >
-  <main class="bg-white py-8 sm:py-16">
+  <main class="bg-[#FAFAF8] py-8 sm:py-16">
     <div class="mx-auto max-w-5xl px-6 lg:px-8">
       {/* Hero */}
       <div class="mx-auto max-w-3xl text-center">
@@ -136,7 +136,7 @@ const signUpUrl = import.meta.env.SIGN_UP_URL;
         <p class="text-sm font-medium text-gray-900">Set up takes less than 5 minutes</p>
         <a
           href={signUpUrl}
-          class="mt-3 inline-flex items-center justify-center rounded-md bg-edgy-blue px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-operately-dark-blue"
+          class="mt-3 inline-flex items-center justify-center rounded-md bg-gray-900 px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-gray-800"
         >
           Start free — no credit card needed
         </a>
@@ -227,7 +227,7 @@ const signUpUrl = import.meta.env.SIGN_UP_URL;
         <div class="mt-8 flex flex-col gap-4 sm:flex-row sm:justify-center">
           <a
             href={signUpUrl}
-            class="inline-flex items-center justify-center rounded-md bg-edgy-blue px-5 py-3 text-sm font-semibold text-white shadow-sm hover:bg-operately-dark-blue"
+            class="inline-flex items-center justify-center rounded-md bg-gray-900 px-5 py-3 text-sm font-semibold text-white shadow-sm hover:bg-gray-800"
           >
             Start free on Cloud
           </a>

--- a/src/pages/for/small-teams.astro
+++ b/src/pages/for/small-teams.astro
@@ -31,7 +31,7 @@ const signUpUrl = import.meta.env.SIGN_UP_URL;
   twitterCardType="summary_large_image"
   schema={schema}
 >
-  <main class="bg-white py-8 sm:py-16">
+  <main class="bg-[#FAFAF8] py-8 sm:py-16">
     <div class="mx-auto max-w-5xl px-6 lg:px-8">
       {/* Hero */}
       <div class="mx-auto max-w-3xl text-center">
@@ -136,7 +136,7 @@ const signUpUrl = import.meta.env.SIGN_UP_URL;
         <p class="text-sm font-medium text-gray-900">Set up takes less than 5 minutes</p>
         <a
           href={signUpUrl}
-          class="mt-3 inline-flex items-center justify-center rounded-md bg-edgy-blue px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-operately-dark-blue"
+          class="mt-3 inline-flex items-center justify-center rounded-md bg-gray-900 px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-gray-800"
         >
           Start free — no credit card needed
         </a>
@@ -237,7 +237,7 @@ const signUpUrl = import.meta.env.SIGN_UP_URL;
         <div class="mt-8 flex flex-col gap-4 sm:flex-row sm:justify-center">
           <a
             href={signUpUrl}
-            class="inline-flex items-center justify-center rounded-md bg-edgy-blue px-5 py-3 text-sm font-semibold text-white shadow-sm hover:bg-operately-dark-blue"
+            class="inline-flex items-center justify-center rounded-md bg-gray-900 px-5 py-3 text-sm font-semibold text-white shadow-sm hover:bg-gray-800"
           >
             Start free on Cloud
           </a>

--- a/src/pages/handbook.astro
+++ b/src/pages/handbook.astro
@@ -53,7 +53,7 @@ const socialImageUrl = new URL(
           </p>
           <a
             href="/handbook/getting-started/"
-            class="bg-operately-blue hover:bg-operately-dark-blue text-white font-semibold py-2.5 px-4 rounded-full"
+            class="bg-operately-blue hover:bg-gray-800 text-white font-semibold py-2.5 px-4 rounded-full"
             >Start Reading →</a
           >
 

--- a/src/pages/okr-software.astro
+++ b/src/pages/okr-software.astro
@@ -31,7 +31,7 @@ const signUpUrl = import.meta.env.SIGN_UP_URL;
   twitterCardType="summary_large_image"
   schema={schema}
 >
-  <main class="bg-white py-8 sm:py-16">
+  <main class="bg-[#FAFAF8] py-8 sm:py-16">
     <div class="mx-auto max-w-5xl px-6 lg:px-8">
       {/* Hero */}
       <div class="mx-auto max-w-3xl text-center">
@@ -208,7 +208,7 @@ const signUpUrl = import.meta.env.SIGN_UP_URL;
         <p class="text-sm font-medium text-gray-900">Ready to try a different approach to OKRs?</p>
         <a
           href={signUpUrl}
-          class="mt-3 inline-flex items-center justify-center rounded-md bg-edgy-blue px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-operately-dark-blue"
+          class="mt-3 inline-flex items-center justify-center rounded-md bg-gray-900 px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-gray-800"
         >
           Start free — no credit card needed
         </a>
@@ -286,7 +286,7 @@ const signUpUrl = import.meta.env.SIGN_UP_URL;
         <div class="mt-8 flex flex-col gap-4 sm:flex-row sm:justify-center">
           <a
             href={signUpUrl}
-            class="inline-flex items-center justify-center rounded-md bg-edgy-blue px-5 py-3 text-sm font-semibold text-white shadow-sm hover:bg-operately-dark-blue"
+            class="inline-flex items-center justify-center rounded-md bg-gray-900 px-5 py-3 text-sm font-semibold text-white shadow-sm hover:bg-gray-800"
           >
             Start free on Cloud
           </a>

--- a/src/pages/open-source.astro
+++ b/src/pages/open-source.astro
@@ -15,7 +15,7 @@ const pageDescription =
   image={"/images/social/card-summary-large.png"}
   twitterCardType="summary_large_image"
 >
-  <main class="bg-white py-8 sm:py-16">
+  <main class="bg-[#FAFAF8] py-8 sm:py-16">
     <Statement />
     <PublicChannels />
   </main>

--- a/src/pages/open-source.astro
+++ b/src/pages/open-source.astro
@@ -18,5 +18,6 @@ const pageDescription =
   <main class="bg-[#FAFAF8] py-8 sm:py-16">
     <Statement />
     <PublicChannels />
+    <div class="mt-16 mb-8 mx-auto max-w-6xl border-t border-gray-200"></div>
   </main>
 </BaseLayout>

--- a/src/pages/pricing.astro
+++ b/src/pages/pricing.astro
@@ -98,11 +98,7 @@ const signUpUrl = import.meta.env.SIGN_UP_URL;
               <Check className="h-6 w-5 flex-none text-operately-blue" />
               Up to 20 users
             </li>
-            <li class="flex gap-x-3">
-              <Check className="h-6 w-5 flex-none text-operately-blue" />
-              AI agents - 25 messages/mo
-            </li>
-            <li class="flex gap-x-3">
+                        <li class="flex gap-x-3">
               <Check className="h-6 w-5 flex-none text-operately-blue" />
               1GB storage
             </li>
@@ -117,7 +113,7 @@ const signUpUrl = import.meta.env.SIGN_UP_URL;
           </ul>
           <a
             href={signUpUrl + "?plan=free"}
-            class="mt-8 block rounded-md bg-gray-900 px-3 py-2 text-center text-sm/6 font-semibold text-white shadow-sm hover:bg-gray-800 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-operately-blue transition-colors"
+            class="mt-8 block rounded-md border border-gray-300 px-3 py-2 text-center text-sm/6 font-semibold text-gray-900 hover:border-gray-900 transition-colors"
           >
             Get started
           </a>
@@ -156,21 +152,13 @@ const signUpUrl = import.meta.env.SIGN_UP_URL;
               <Check className="h-6 w-5 flex-none text-operately-blue" />
               Up to 50 users
             </li>
-            <li class="flex gap-x-3">
-              <Check className="h-6 w-5 flex-none text-operately-blue" />
-              AI agents - 500 messages/mo
-            </li>
-            <li class="flex gap-x-3">
+                        <li class="flex gap-x-3">
               <Check className="h-6 w-5 flex-none text-operately-blue" />
               100 GB storage
             </li>
             <li class="flex gap-x-3">
               <Check className="h-6 w-5 flex-none text-operately-blue" />
               Priority support
-            </li>
-            <li class="flex gap-x-3">
-              <Check className="h-6 w-5 flex-none text-operately-blue" />
-              AI, storage packs available
             </li>
           </ul>
           <a
@@ -209,11 +197,7 @@ const signUpUrl = import.meta.env.SIGN_UP_URL;
               <Check className="h-6 w-5 flex-none text-operately-blue" />
               Up to 200 users
             </li>
-            <li class="flex gap-x-3">
-              <Check className="h-6 w-5 flex-none text-operately-blue" />
-              AI agents - 2,500 messages/mo
-            </li>
-            <li class="flex gap-x-3">
+                        <li class="flex gap-x-3">
               <Check className="h-6 w-5 flex-none text-operately-blue" />
               1 TB storage
             </li>
@@ -228,7 +212,7 @@ const signUpUrl = import.meta.env.SIGN_UP_URL;
           </ul>
           <a
             href={signUpUrl + "?plan=business"}
-            class="mt-8 block rounded-md bg-gray-900 px-3 py-2 text-center text-sm/6 font-semibold text-white shadow-sm hover:bg-gray-800 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-operately-blue transition-colors"
+            class="mt-8 block rounded-md border border-gray-300 px-3 py-2 text-center text-sm/6 font-semibold text-gray-900 hover:border-gray-900 transition-colors"
           >
             Get started
           </a>

--- a/src/pages/pricing.astro
+++ b/src/pages/pricing.astro
@@ -72,7 +72,7 @@ const signUpUrl = import.meta.env.SIGN_UP_URL;
         class="isolate mx-auto mt-16 grid max-w-5xl grid-cols-1 gap-8 lg:grid-cols-3"
       >
         {/* Free Plan */}
-        <div class="rounded-3xl p-8 ring-2 ring-gray-300 shadow-lg xl:p-10">
+        <div class="rounded-3xl p-8 ring-1 ring-gray-200 shadow-md xl:p-10">
           <div class="flex items-center justify-between gap-x-4">
             <h3 class="text-lg/8 font-semibold text-gray-900">Free</h3>
           </div>
@@ -121,7 +121,7 @@ const signUpUrl = import.meta.env.SIGN_UP_URL;
 
         {/* Team Plan */}
         <div
-          class="rounded-3xl p-8 ring-2 ring-operately-blue shadow-xl xl:p-10"
+          class="rounded-3xl p-8 ring-2 ring-operately-blue shadow-2xl xl:p-10"
         >
           <div class="flex items-center justify-between gap-x-4">
             <h3 class="text-lg/8 font-semibold text-operately-blue">Team</h3>
@@ -170,7 +170,7 @@ const signUpUrl = import.meta.env.SIGN_UP_URL;
         </div>
 
         {/* Business Plan */}
-        <div class="rounded-3xl p-8 ring-2 ring-gray-300 shadow-lg xl:p-10">
+        <div class="rounded-3xl p-8 ring-1 ring-gray-200 shadow-md xl:p-10">
           <div class="flex items-center justify-between gap-x-4">
             <h3 class="text-lg/8 font-semibold text-gray-900">Business</h3>
           </div>
@@ -253,8 +253,8 @@ const signUpUrl = import.meta.env.SIGN_UP_URL;
         <h2 class="text-3xl font-bold text-center text-gray-900">
           Frequently Asked Questions
         </h2>
-        <div class="mt-12 space-y-8">
-          <div>
+        <div class="mt-12 space-y-0 divide-y divide-gray-200">
+          <div class="py-8">
             <h3 class="text-lg font-semibold text-gray-900">
               Is there really no per-seat pricing?
             </h3>
@@ -264,7 +264,7 @@ const signUpUrl = import.meta.env.SIGN_UP_URL;
               costs or surprise bills.
             </p>
           </div>
-          <div>
+          <div class="py-8">
             <h3 class="text-lg font-semibold text-gray-900">
               What happens if I exceed my user limit?
             </h3>
@@ -274,7 +274,7 @@ const signUpUrl = import.meta.env.SIGN_UP_URL;
               you'll only pay the difference.
             </p>
           </div>
-          <div>
+          <div class="py-8">
             <h3 class="text-lg font-semibold text-gray-900">
               Can I self-host Operately?
             </h3>
@@ -294,7 +294,7 @@ const signUpUrl = import.meta.env.SIGN_UP_URL;
               >.
             </p>
           </div>
-          <div>
+          <div class="py-8">
             <h3 class="text-lg font-semibold text-gray-900">
               Do I need a credit card to start?
             </h3>
@@ -303,7 +303,7 @@ const signUpUrl = import.meta.env.SIGN_UP_URL;
               Operately immediately and upgrade when you're ready.
             </p>
           </div>
-          <div>
+          <div class="py-8">
             <h3 class="text-lg font-semibold text-gray-900">
               Can I cancel anytime?
             </h3>
@@ -314,7 +314,7 @@ const signUpUrl = import.meta.env.SIGN_UP_URL;
               required.
             </p>
           </div>
-          <div>
+          <div class="py-8">
             <h3 class="text-lg font-semibold text-gray-900">
               What's included in the annual discount?
             </h3>
@@ -324,7 +324,7 @@ const signUpUrl = import.meta.env.SIGN_UP_URL;
               the same features with no additional costs.
             </p>
           </div>
-          <div>
+          <div class="py-8">
             <h3 class="text-lg font-semibold text-gray-900">
               What if I need more than 200 users?
             </h3>

--- a/src/pages/pricing.astro
+++ b/src/pages/pricing.astro
@@ -16,7 +16,7 @@ const signUpUrl = import.meta.env.SIGN_UP_URL;
   image={"/images/social/card-summary-large.png"}
   twitterCardType="summary_large_image"
 >
-  <main class="bg-white py-8 sm:py-16">
+  <main class="bg-[#FAFAF8] py-8 sm:py-16">
     <div class="mx-auto max-w-7xl px-6 lg:px-8">
       {/* Header */}
       <div class="mx-auto max-w-4xl text-center">
@@ -117,7 +117,7 @@ const signUpUrl = import.meta.env.SIGN_UP_URL;
           </ul>
           <a
             href={signUpUrl + "?plan=free"}
-            class="mt-8 block rounded-md bg-edgy-blue px-3 py-2 text-center text-sm/6 font-semibold text-white shadow-sm hover:bg-operately-dark-blue focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-operately-blue transition-colors"
+            class="mt-8 block rounded-md bg-gray-900 px-3 py-2 text-center text-sm/6 font-semibold text-white shadow-sm hover:bg-gray-800 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-operately-blue transition-colors"
           >
             Get started
           </a>
@@ -175,7 +175,7 @@ const signUpUrl = import.meta.env.SIGN_UP_URL;
           </ul>
           <a
             href={signUpUrl + "?plan=team"}
-            class="mt-8 block rounded-md bg-edgy-blue px-3 py-2 text-center text-sm/6 font-semibold text-white shadow-sm hover:bg-operately-dark-blue focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-operately-blue transition-colors"
+            class="mt-8 block rounded-md bg-gray-900 px-3 py-2 text-center text-sm/6 font-semibold text-white shadow-sm hover:bg-gray-800 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-operately-blue transition-colors"
           >
             Get started
           </a>
@@ -228,7 +228,7 @@ const signUpUrl = import.meta.env.SIGN_UP_URL;
           </ul>
           <a
             href={signUpUrl + "?plan=business"}
-            class="mt-8 block rounded-md bg-edgy-blue px-3 py-2 text-center text-sm/6 font-semibold text-white shadow-sm hover:bg-operately-dark-blue focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-operately-blue transition-colors"
+            class="mt-8 block rounded-md bg-gray-900 px-3 py-2 text-center text-sm/6 font-semibold text-white shadow-sm hover:bg-gray-800 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-operately-blue transition-colors"
           >
             Get started
           </a>
@@ -256,7 +256,7 @@ const signUpUrl = import.meta.env.SIGN_UP_URL;
             </a>
             <a
               href="/contact?help-type=commercial-license"
-              class="inline-block rounded-md bg-edgy-blue px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-operately-dark-blue transition-colors"
+              class="inline-block rounded-md bg-gray-900 px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-gray-800 transition-colors"
             >
               Contact us
             </a>

--- a/src/pages/pricing.astro
+++ b/src/pages/pricing.astro
@@ -92,11 +92,11 @@ const signUpUrl = import.meta.env.SIGN_UP_URL;
           >
             <li class="flex gap-x-3">
               <Check className="h-6 w-5 flex-none text-operately-blue" />
-              <span class="bg-yellow-300 px-1 rounded">All core features</span>
+              All core features
             </li>
             <li class="flex gap-x-3">
               <Check className="h-6 w-5 flex-none text-operately-blue" />
-              <span class="bg-yellow-300 px-1 rounded">Up to 20 users</span>
+              Up to 20 users
             </li>
             <li class="flex gap-x-3">
               <Check className="h-6 w-5 flex-none text-operately-blue" />
@@ -238,7 +238,7 @@ const signUpUrl = import.meta.env.SIGN_UP_URL;
       {/* Self-hosted CTA */}
       <div class="mx-auto mt-16 max-w-2xl">
         <div
-          class="rounded-3xl bg-slate-100 p-8 text-center shadow-lg ring-1 ring-slate-200"
+          class="rounded-3xl bg-[#F5F5F0] p-8 text-center shadow-lg ring-1 ring-gray-200"
         >
           <h3 class="text-lg font-semibold text-gray-900">
             Looking for a commercial self-hosted license?

--- a/src/pages/releases/[...slug].astro
+++ b/src/pages/releases/[...slug].astro
@@ -103,7 +103,7 @@ const jsonLd = JSON.stringify({
         {formatDate(entry.data.date)}
       </time>
     </p>
-    <div class="prose max-w-none text-lg">
+    <div class="prose max-w-none text-lg prose-a:text-operately-blue prose-pre:bg-[#F0EDE8] prose-pre:text-gray-800 prose-pre:rounded-xl">
       {
         entry.data.youtubeId && (
           <div class="mb-8">

--- a/src/pages/releases/[...slug].astro
+++ b/src/pages/releases/[...slug].astro
@@ -103,7 +103,7 @@ const jsonLd = JSON.stringify({
         {formatDate(entry.data.date)}
       </time>
     </p>
-    <div class="prose max-w-none text-lg prose-a:text-operately-blue prose-pre:bg-[#F0EDE8] prose-pre:text-gray-800 prose-pre:rounded-xl">
+    <div class="prose max-w-none text-lg prose-a:!text-operately-blue prose-pre:bg-[#F0EDE8] prose-pre:text-gray-800 prose-pre:rounded-xl">
       {
         entry.data.youtubeId && (
           <div class="mb-8">

--- a/src/pages/releases/index.astro
+++ b/src/pages/releases/index.astro
@@ -41,7 +41,7 @@ const { Content: LatestReleaseContent } = latestRelease
           </a>
         </h2>
         <p class="text-gray-500 mb-2">{formatDate(latestRelease.data.date)}</p>
-        <div class="prose max-w-none">
+        <div class="prose max-w-none prose-a:text-operately-blue prose-pre:bg-[#F0EDE8] prose-pre:text-gray-800 prose-pre:rounded-xl">
           {LatestReleaseContent && <LatestReleaseContent />}
         </div>
       </article>

--- a/src/pages/releases/index.astro
+++ b/src/pages/releases/index.astro
@@ -41,7 +41,7 @@ const { Content: LatestReleaseContent } = latestRelease
           </a>
         </h2>
         <p class="text-gray-500 mb-2">{formatDate(latestRelease.data.date)}</p>
-        <div class="prose max-w-none prose-a:text-operately-blue prose-pre:bg-[#F0EDE8] prose-pre:text-gray-800 prose-pre:rounded-xl">
+        <div class="prose max-w-none prose-a:!text-operately-blue prose-pre:bg-[#F0EDE8] prose-pre:text-gray-800 prose-pre:rounded-xl">
           {LatestReleaseContent && <LatestReleaseContent />}
         </div>
       </article>

--- a/src/pages/roadmap.astro
+++ b/src/pages/roadmap.astro
@@ -65,7 +65,7 @@ const features = {
   image={"/images/social/card-summary-large.png"}
   twitterCardType="summary_large_image"
 >
-  <main class="bg-white">
+  <main class="bg-[#FAFAF8]">
     <div class="min-h-screen text-gray-900 py-8 lg:py-16">
       <div class="max-w-4xl mx-auto px-6">
         <div class="prose">
@@ -88,7 +88,7 @@ const features = {
           <div class="space-y-4">
             {
               features.active.map((feature) => (
-                <div class="bg-white rounded-lg p-6 hover:bg-gray-50 transition shadow-sm border border-gray-200">
+                <div class="bg-[#FAFAF8] rounded-lg p-6 hover:bg-gray-50 transition shadow-sm border border-gray-200">
                   <h3 class="text-xl text-gray-900 mb-2">{feature.title}</h3>
                   <p class="text-gray-600">{feature.description}</p>
                   {
@@ -117,7 +117,7 @@ const features = {
           <div class="space-y-4">
             {
               features.planned.map((feature) => (
-                <div class="bg-white rounded-lg p-6 hover:bg-gray-50 transition shadow-sm border border-gray-200">
+                <div class="bg-[#FAFAF8] rounded-lg p-6 hover:bg-gray-50 transition shadow-sm border border-gray-200">
                   <h3 class="text-xl text-gray-900 mb-2">{feature.title}</h3>
                   <p class="text-gray-600">{feature.description}</p>
                 </div>

--- a/src/pages/self-hosted.astro
+++ b/src/pages/self-hosted.astro
@@ -87,9 +87,9 @@ const schema = {
           alongside the other tools you are probably looking at.
         </p>
         <div class="mt-8 overflow-hidden rounded-xl border border-slate-200 bg-white">
-          <table class="w-full text-sm">
-            <thead>
-              <tr class="border-b border-slate-200 bg-slate-100">
+          <table class="w-full text-sm divide-y divide-gray-100">
+            <thead class="bg-gray-50">
+              <tr class="border-b border-gray-200">
                 <th class="px-5 py-3 text-left font-medium text-gray-500"></th>
                 <th class="px-5 py-3 text-center font-medium text-gray-900">Operately</th>
                 <th class="px-5 py-3 text-center font-medium text-gray-900">OpenProject</th>
@@ -160,7 +160,7 @@ const schema = {
       <div class="mx-auto mt-16 max-w-4xl">
         <h2 class="text-3xl font-semibold text-gray-900">Common next steps</h2>
         <div class="mt-8 grid gap-6 sm:grid-cols-2">
-          <a href="/install" class="group block rounded-2xl border border-gray-200 bg-white p-6 shadow-sm transition hover:border-operately-blue hover:bg-slate-50 hover:shadow-md focus:outline-none focus-visible:ring-2 focus-visible:ring-operately-blue focus-visible:ring-offset-2">
+          <a href="/install" class="group block rounded-2xl border border-gray-200 bg-white p-8 shadow-sm transition hover:border-operately-blue hover:bg-slate-50 hover:shadow-md focus:outline-none focus-visible:ring-2 focus-visible:ring-operately-blue focus-visible:ring-offset-2">
             <div class="flex items-start justify-between gap-4">
               <div>
                 <p class="text-xs font-semibold uppercase tracking-wide text-operately-blue">Open guide</p>
@@ -173,7 +173,7 @@ const schema = {
             </p>
           </a>
 
-          <a href="/help/self-hosted-installation" class="group block rounded-2xl border border-gray-200 bg-white p-6 shadow-sm transition hover:border-operately-blue hover:bg-slate-50 hover:shadow-md focus:outline-none focus-visible:ring-2 focus-visible:ring-operately-blue focus-visible:ring-offset-2">
+          <a href="/help/self-hosted-installation" class="group block rounded-2xl border border-gray-200 bg-white p-8 shadow-sm transition hover:border-operately-blue hover:bg-slate-50 hover:shadow-md focus:outline-none focus-visible:ring-2 focus-visible:ring-operately-blue focus-visible:ring-offset-2">
             <div class="flex items-start justify-between gap-4">
               <div>
                 <p class="text-xs font-semibold uppercase tracking-wide text-operately-blue">Browse docs</p>
@@ -186,7 +186,7 @@ const schema = {
             </p>
           </a>
 
-          <a href="/pricing" class="group block rounded-2xl border border-gray-200 bg-white p-6 shadow-sm transition hover:border-operately-blue hover:bg-slate-50 hover:shadow-md focus:outline-none focus-visible:ring-2 focus-visible:ring-operately-blue focus-visible:ring-offset-2">
+          <a href="/pricing" class="group block rounded-2xl border border-gray-200 bg-white p-8 shadow-sm transition hover:border-operately-blue hover:bg-slate-50 hover:shadow-md focus:outline-none focus-visible:ring-2 focus-visible:ring-operately-blue focus-visible:ring-offset-2">
             <div class="flex items-start justify-between gap-4">
               <div>
                 <p class="text-xs font-semibold uppercase tracking-wide text-operately-blue">Review pricing</p>
@@ -199,7 +199,7 @@ const schema = {
             </p>
           </a>
 
-          <a href="/open-source" class="group block rounded-2xl border border-gray-200 bg-white p-6 shadow-sm transition hover:border-operately-blue hover:bg-slate-50 hover:shadow-md focus:outline-none focus-visible:ring-2 focus-visible:ring-operately-blue focus-visible:ring-offset-2">
+          <a href="/open-source" class="group block rounded-2xl border border-gray-200 bg-white p-8 shadow-sm transition hover:border-operately-blue hover:bg-slate-50 hover:shadow-md focus:outline-none focus-visible:ring-2 focus-visible:ring-operately-blue focus-visible:ring-offset-2">
             <div class="flex items-start justify-between gap-4">
               <div>
                 <p class="text-xs font-semibold uppercase tracking-wide text-operately-blue">Read context</p>

--- a/src/pages/self-hosted.astro
+++ b/src/pages/self-hosted.astro
@@ -27,7 +27,7 @@ const schema = {
   twitterCardType="summary_large_image"
   schema={schema}
 >
-  <main class="bg-white py-8 sm:py-16">
+  <main class="bg-[#FAFAF8] py-8 sm:py-16">
     <div class="mx-auto max-w-5xl px-6 lg:px-8">
       <div class="mx-auto max-w-3xl text-center">
         <p class="text-sm font-semibold uppercase tracking-wide text-operately-blue">
@@ -46,7 +46,7 @@ const schema = {
       <div class="mx-auto mt-10 flex max-w-3xl flex-col gap-4 sm:flex-row sm:justify-center">
         <a
           href="/install"
-          class="inline-flex items-center justify-center rounded-md bg-edgy-blue px-5 py-3 text-sm font-semibold text-white shadow-sm hover:bg-operately-dark-blue"
+          class="inline-flex items-center justify-center rounded-md bg-gray-900 px-5 py-3 text-sm font-semibold text-white shadow-sm hover:bg-gray-800"
         >
           Go to installation guide
         </a>

--- a/src/pages/vs/asana.astro
+++ b/src/pages/vs/asana.astro
@@ -29,7 +29,7 @@ const signUpUrl = import.meta.env.SIGN_UP_URL;
   twitterCardType="summary_large_image"
   schema={schema}
 >
-  <main class="bg-white py-8 sm:py-16">
+  <main class="bg-[#FAFAF8] py-8 sm:py-16">
     <div class="mx-auto max-w-5xl px-6 lg:px-8">
       {/* Hero */}
       <div class="mx-auto max-w-3xl text-center">
@@ -203,7 +203,7 @@ const signUpUrl = import.meta.env.SIGN_UP_URL;
         <p class="text-sm font-medium text-gray-900">Want to see Operately in action?</p>
         <a
           href={signUpUrl}
-          class="mt-3 inline-flex items-center justify-center rounded-md bg-edgy-blue px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-operately-dark-blue"
+          class="mt-3 inline-flex items-center justify-center rounded-md bg-gray-900 px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-gray-800"
         >
           Try free — no credit card needed
         </a>
@@ -309,7 +309,7 @@ const signUpUrl = import.meta.env.SIGN_UP_URL;
         <div class="mt-8 flex flex-col gap-4 sm:flex-row sm:justify-center">
           <a
             href={signUpUrl}
-            class="inline-flex items-center justify-center rounded-md bg-edgy-blue px-5 py-3 text-sm font-semibold text-white shadow-sm hover:bg-operately-dark-blue"
+            class="inline-flex items-center justify-center rounded-md bg-gray-900 px-5 py-3 text-sm font-semibold text-white shadow-sm hover:bg-gray-800"
           >
             Start free on Cloud
           </a>

--- a/src/pages/vs/monday.astro
+++ b/src/pages/vs/monday.astro
@@ -29,7 +29,7 @@ const signUpUrl = import.meta.env.SIGN_UP_URL;
   twitterCardType="summary_large_image"
   schema={schema}
 >
-  <main class="bg-white py-8 sm:py-16">
+  <main class="bg-[#FAFAF8] py-8 sm:py-16">
     <div class="mx-auto max-w-5xl px-6 lg:px-8">
       {/* Hero */}
       <div class="mx-auto max-w-3xl text-center">
@@ -198,7 +198,7 @@ const signUpUrl = import.meta.env.SIGN_UP_URL;
         <p class="text-sm font-medium text-gray-900">Want to see Operately in action?</p>
         <a
           href={signUpUrl}
-          class="mt-3 inline-flex items-center justify-center rounded-md bg-edgy-blue px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-operately-dark-blue"
+          class="mt-3 inline-flex items-center justify-center rounded-md bg-gray-900 px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-gray-800"
         >
           Try free — no credit card needed
         </a>
@@ -303,7 +303,7 @@ const signUpUrl = import.meta.env.SIGN_UP_URL;
         <div class="mt-8 flex flex-col gap-4 sm:flex-row sm:justify-center">
           <a
             href={signUpUrl}
-            class="inline-flex items-center justify-center rounded-md bg-edgy-blue px-5 py-3 text-sm font-semibold text-white shadow-sm hover:bg-operately-dark-blue"
+            class="inline-flex items-center justify-center rounded-md bg-gray-900 px-5 py-3 text-sm font-semibold text-white shadow-sm hover:bg-gray-800"
           >
             Start free on Cloud
           </a>

--- a/src/pages/what-is-operately.astro
+++ b/src/pages/what-is-operately.astro
@@ -98,7 +98,7 @@ const signUpUrl = import.meta.env.SIGN_UP_URL;
   twitterCardType="summary_large_image"
   schema={schema}
 >
-  <main class="bg-white py-8 sm:py-16">
+  <main class="bg-[#FAFAF8] py-8 sm:py-16">
     <div class="mx-auto max-w-5xl px-6 lg:px-8">
       {/* Hero */}
       <div class="mx-auto max-w-3xl text-center">
@@ -266,7 +266,7 @@ const signUpUrl = import.meta.env.SIGN_UP_URL;
         <div class="mt-8 flex flex-col gap-4 sm:flex-row sm:justify-center">
           <a
             href={signUpUrl}
-            class="inline-flex items-center justify-center rounded-md bg-edgy-blue px-5 py-3 text-sm font-semibold text-white shadow-sm hover:bg-operately-dark-blue"
+            class="inline-flex items-center justify-center rounded-md bg-gray-900 px-5 py-3 text-sm font-semibold text-white shadow-sm hover:bg-gray-800"
           >
             Start free on Cloud
           </a>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,10 +1,13 @@
 @import "tailwindcss";
 @plugin "@tailwindcss/typography";
 
+/* Global warm background */
+body { background-color: #FAFAF8; }
+
 /* Custom color utilities - ensure they're available */
-.text-operately-blue { color: #3185FF; }
-.bg-operately-blue { background-color: #3185FF; }
-.border-operately-blue { border-color: #3185FF; }
+.text-operately-blue { color: #0055FF; }
+.bg-operately-blue { background-color: #0055FF; }
+.border-operately-blue { border-color: #0055FF; }
 
 .text-operately-dark-blue { color: #024FAC; }
 .bg-operately-dark-blue { background-color: #024FAC; }

--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -6,7 +6,7 @@ export default {
       /* FIXME: this for some reason is not working after upgrading to Tailwind 4 */
       /* we have colors defined in global.css */
       colors: {
-        "operately-blue": "#3185FF",
+        "operately-blue": "#0055FF",
         "operately-dark-blue": "#024FAC",
         "operately-blue-tint-1": "#E3F2FF",
         "operately-blue-tint-2": "#98C9FF",


### PR DESCRIPTION
Full website refresh: warmer style, stronger blue accent, dark nav buttons, looping screencast, consistent backgrounds across all pages.

## Changes

- Warm off-white background (#FAFAF8) set globally via body in global.css
- Blue accent strengthened from #3185FF to #0055FF (passes WCAG AA on warm bg)
- Hero screenshot replaced with looping screencast video (Cloudflare R2)
- Nav CTA button changed from blue to dark (bg-gray-900)
- All page-level CTA buttons changed from blue to dark
- Testimonial attributions shortened (FirstName L., Title)
- Jobs page removed from nav and footer (not hiring)
- Pricing: removed yellow highlight tags, warmed callout box
- Contact: blue button fixed to dark

## Pages checklist

- [x] Homepage (index) — redesigned with warm bg, video, inline testimonials, dark section
- [x] Navigation — dark CTA button, Jobs removed
- [x] Footer — background updated to warm, Jobs removed
- [x] /pricing — warm bg, dark buttons, removed yellow tags, warmed callout
- [x] /features — warm bg, dark buttons
- [x] /ai — warm bg, dark buttons
- [x] /self-hosted — warm bg, dark buttons
- [x] /for/small-teams — warm bg, dark buttons
- [x] /for/nonprofits — warm bg, dark buttons
- [x] /vs/monday — warm bg, dark buttons
- [x] /vs/asana — warm bg, dark buttons
- [x] /okr-software — warm bg, dark buttons
- [x] /what-is-operately — warm bg, dark buttons
- [x] /open-source — warm bg, dark buttons
- [x] /contact — warm bg, dark button (was blue)
- [x] /handbook — uses own layout, no change needed
- [x] /roadmap — warm bg, dark buttons
- [x] /releases — warm bg via layout fix
- [x] /masterplan — warm bg via Article layout fix
- [x] /install — warm bg via Article layout fix
- [x] /legal/* — warm bg via Article layout fix
- [x] /404 — warm bg

## Global changes (affect all pages)

- `global.css`: body background-color set to #FAFAF8
- `global.css`: operately-blue changed to #0055FF
- `tailwind.config.mjs`: operately-blue updated to #0055FF
- `Footer.astro`: bg-[#FAFAF8], Jobs link removed
- `Navigation.jsx`: dark CTA button, Jobs link removed
- `Article.astro`: bg-white to bg-[#FAFAF8]
- `ReleasesLayout.astro`: wrapped in warm bg div

## Out of scope

- New page content
- Logo/brand changes
- Real testimonials (waiting for quotes from early users)

Closes operately/gtm-context#38