### PR TITLE
Add homepage screencast video

### DIFF
--- a/src/pages/_index/HomePage.astro
+++ b/src/pages/_index/HomePage.astro
@@ -6,6 +6,7 @@ const pageDescription =
   "Open source project management with built-in OKR goal tracking. Run goals, projects, and check-ins with structure that keeps your team aligned. Free to start, self-host in minutes.";
 
 import Hero from "./Hero.astro";
+import Screencast from "./Screencast.astro";
 import Intro from "./Intro.astro";
 import Goals from "./Goals.astro";
 import Projects from "./Projects.astro";
@@ -74,6 +75,7 @@ const schema = [
 >
   <main>
     <Hero latestRelease={latestRelease} />
+    <Screencast />
     <Intro />
     <Goals />
     <Projects />

--- a/src/pages/_index/Screencast.astro
+++ b/src/pages/_index/Screencast.astro
@@ -1,0 +1,21 @@
+---
+---
+
+<section class="relative bg-white pb-16 sm:pb-24">
+  <div class="mx-auto max-w-5xl px-4 sm:px-6 lg:px-8">
+    <div class="overflow-hidden rounded-xl shadow-2xl ring-1 ring-gray-900/10">
+      <video
+        autoplay
+        loop
+        muted
+        playsinline
+        class="w-full h-auto"
+      >
+        <source
+          src="https://website-assets.operately.com/operately-homepage-screencast-v1.mp4"
+          type="video/mp4"
+        />
+      </video>
+    </div>
+  </div>
+</section>


### PR DESCRIPTION
Adds a looping product screencast video right below the hero section on the homepage.

- Video hosted on Cloudflare R2 (no repo bloat)
- Autoplay, loop, muted, playsinline (works in all browsers)
- Rounded container with shadow for a polished look
- 48s demo showing: Work Map → Goal → Project → Check-in → progress rolls up

Preview will be on the Cloudflare Pages deploy preview for this branch.

Closes operately/gtm-context#38