### PR TITLE
fix: Add PUBLIC_ prefix to link variables

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -12,8 +12,8 @@ const githubUrl = import.meta.env.PUBLIC_GITHUB_URL;
 const linkedinUrl = import.meta.env.PUBLIC_LINKEDIN_URL;
 const xUrl = import.meta.env.PUBLIC_X_URL;
 const youtubeUrl = import.meta.env.PUBLIC_YOUTUBE_URL;
-const signUpUrl = import.meta.env.SIGN_UP_URL;
-const logInUrl = import.meta.env.LOG_IN_URL;
+const signUpUrl = import.meta.env.PUBLIC_SIGN_UP_URL;
+const logInUrl = import.meta.env.PUBLIC_LOG_IN_URL;
 
 const navigation = {
   product: [

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -17,7 +17,7 @@ const logInUrl = import.meta.env.PUBLIC_LOG_IN_URL;
 
 const navigation = {
   product: [
-    { name: "Features", href: "/#features" },
+    { name: "Features", href: "/features" },
     { name: "Releases", href: "/releases" },
     { name: "Roadmap", href: "/roadmap" },
     { name: "Status", href: "https://status.operately.com" },

--- a/src/pages/ai.astro
+++ b/src/pages/ai.astro
@@ -19,7 +19,7 @@ const schema = {
   },
 };
 
-const signUpUrl = import.meta.env.SIGN_UP_URL;
+const signUpUrl = import.meta.env.PUBLIC_SIGN_UP_URL;
 ---
 
 <BaseLayout

--- a/src/pages/for/nonprofits.astro
+++ b/src/pages/for/nonprofits.astro
@@ -21,7 +21,7 @@ const schema = {
   },
 };
 
-const signUpUrl = import.meta.env.SIGN_UP_URL;
+const signUpUrl = import.meta.env.PUBLIC_SIGN_UP_URL;
 ---
 
 <BaseLayout

--- a/src/pages/for/small-teams.astro
+++ b/src/pages/for/small-teams.astro
@@ -21,7 +21,7 @@ const schema = {
   },
 };
 
-const signUpUrl = import.meta.env.SIGN_UP_URL;
+const signUpUrl = import.meta.env.PUBLIC_SIGN_UP_URL;
 ---
 
 <BaseLayout

--- a/src/pages/okr-software.astro
+++ b/src/pages/okr-software.astro
@@ -21,7 +21,7 @@ const schema = {
   },
 };
 
-const signUpUrl = import.meta.env.SIGN_UP_URL;
+const signUpUrl = import.meta.env.PUBLIC_SIGN_UP_URL;
 ---
 
 <BaseLayout

--- a/src/pages/pricing.astro
+++ b/src/pages/pricing.astro
@@ -7,7 +7,7 @@ const pageDescription =
 
 import { Check } from "lucide-react";
 
-const signUpUrl = import.meta.env.SIGN_UP_URL;
+const signUpUrl = import.meta.env.PUBLIC_SIGN_UP_URL;
 ---
 
 <BaseLayout

--- a/src/pages/vs/asana.astro
+++ b/src/pages/vs/asana.astro
@@ -19,7 +19,7 @@ const schema = {
   },
 };
 
-const signUpUrl = import.meta.env.SIGN_UP_URL;
+const signUpUrl = import.meta.env.PUBLIC_SIGN_UP_URL;
 ---
 
 <BaseLayout

--- a/src/pages/vs/monday.astro
+++ b/src/pages/vs/monday.astro
@@ -19,7 +19,7 @@ const schema = {
   },
 };
 
-const signUpUrl = import.meta.env.SIGN_UP_URL;
+const signUpUrl = import.meta.env.PUBLIC_SIGN_UP_URL;
 ---
 
 <BaseLayout

--- a/src/pages/what-is-operately.astro
+++ b/src/pages/what-is-operately.astro
@@ -88,7 +88,7 @@ const schema = [
   },
 ];
 
-const signUpUrl = import.meta.env.SIGN_UP_URL;
+const signUpUrl = import.meta.env.PUBLIC_SIGN_UP_URL;
 ---
 
 <BaseLayout


### PR DESCRIPTION
Several links in the website were undefined because we were using SIGN_UP_URL and LOG_IN_URL without the PUBLIC_ prefix.