### PR TITLE
Add dynamic OG images for release pages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@astrojs/rss": "^4.0.12",
         "@astrojs/sitemap": "^3.7.2",
         "@astrojs/starlight": "^0.35.2",
+        "@fontsource/inter": "^5.2.8",
         "@headlessui/react": "^2.2.0",
         "@tailwindcss/typography": "^0.5.16",
         "@tailwindcss/vite": "^4.1.11",
@@ -27,6 +28,8 @@
         "rehype-autolink-headings": "^7.1.0",
         "rehype-slug": "^6.0.0",
         "sanitize-html": "^2.13.0",
+        "satori": "^0.26.0",
+        "satori-html": "^0.3.2",
         "sharp": "^0.34.5",
         "tailwindcss": "^4.0.0",
         "ultrahtml": "^1.5.3"
@@ -1033,6 +1036,15 @@
       "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.9.tgz",
       "integrity": "sha512-MDWhGtE+eHw5JW7lq4qhc5yRLS11ERl1c7Z6Xd0a58DozHES6EnNNwUWbMiG4J9Cgj053Bhk8zvlhFYKVhULwg==",
       "license": "MIT"
+    },
+    "node_modules/@fontsource/inter": {
+      "version": "5.2.8",
+      "resolved": "https://registry.npmjs.org/@fontsource/inter/-/inter-5.2.8.tgz",
+      "integrity": "sha512-P6r5WnJoKiNVV+zvW2xM13gNdFhAEpQ9dQJHt3naLvfg+LkF2ldgSLiF4T41lf1SQCM9QmkqPTn4TH568IRagg==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
     },
     "node_modules/@headlessui/react": {
       "version": "2.2.1",
@@ -2195,6 +2207,22 @@
       "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
       "license": "MIT"
     },
+    "node_modules/@shuding/opentype.js": {
+      "version": "1.4.0-beta.0",
+      "resolved": "https://registry.npmjs.org/@shuding/opentype.js/-/opentype.js-1.4.0-beta.0.tgz",
+      "integrity": "sha512-3NgmNyH3l/Hv6EvsWJbsvpcpUba6R8IREQ83nH83cyakCw7uM1arZKNfHwv1Wz6jgqrF/j4x5ELvR6PnK9nTcA==",
+      "license": "MIT",
+      "dependencies": {
+        "fflate": "^0.7.3",
+        "string.prototype.codepointat": "^0.2.1"
+      },
+      "bin": {
+        "ot": "bin/ot"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      }
+    },
     "node_modules/@swc/helpers": {
       "version": "0.5.17",
       "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.17.tgz",
@@ -3298,6 +3326,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/camelize": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/camelize/-/camelize-1.0.1.tgz",
+      "integrity": "sha512-dU+Tx2fsypxTgtLoE36npi3UqcjSSMNYfkqgmoEhtZrraP5VWq0K7FkWVTYa8eMPtnU/G2txVsfdCJTn9uzpuQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001741",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001741.tgz",
@@ -3459,6 +3496,12 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT"
+    },
     "node_modules/comma-separated-tokens": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
@@ -3514,6 +3557,36 @@
         "uncrypto": "^0.1.3"
       }
     },
+    "node_modules/css-background-parser": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/css-background-parser/-/css-background-parser-0.1.0.tgz",
+      "integrity": "sha512-2EZLisiZQ+7m4wwur/qiYJRniHX4K5Tc9w93MT3AS0WS1u5kaZ4FKXlOTBhOjc+CgEgPiGY+fX1yWD8UwpEqUA==",
+      "license": "MIT"
+    },
+    "node_modules/css-box-shadow": {
+      "version": "1.0.0-3",
+      "resolved": "https://registry.npmjs.org/css-box-shadow/-/css-box-shadow-1.0.0-3.tgz",
+      "integrity": "sha512-9jaqR6e7Ohds+aWwmhe6wILJ99xYQbfmK9QQB9CcMjDbTxPZjwEmUQpU91OG05Xgm8BahT5fW+svbsQGjS/zPg==",
+      "license": "MIT"
+    },
+    "node_modules/css-color-keywords": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/css-color-keywords/-/css-color-keywords-1.0.0.tgz",
+      "integrity": "sha512-FyyrDHZKEjXDpNJYvVsV960FiqQyXc/LlYmsxl2BcdMb2WPx0OGRVgTg55rPSyLSNMqP52R9r8geSp7apN3Ofg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/css-gradient-parser": {
+      "version": "0.0.17",
+      "resolved": "https://registry.npmjs.org/css-gradient-parser/-/css-gradient-parser-0.0.17.tgz",
+      "integrity": "sha512-w2Xy9UMMwlKtou0vlRnXvWglPAceXCTtcmVSo8ZBUvqCV5aXEFP/PC6d+I464810I9FT++UACwTD5511bmGPUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/css-selector-parser": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/css-selector-parser/-/css-selector-parser-3.1.2.tgz",
@@ -3529,6 +3602,17 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/css-to-react-native": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/css-to-react-native/-/css-to-react-native-3.2.0.tgz",
+      "integrity": "sha512-e8RKaLXMOFii+02mOlqwjbD00KSEKqblnpO9e++1aXS1fPQOpS1YoqdVHBqPjHNoxeF2mimzVqawm2KCbEdtHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "camelize": "^1.0.0",
+        "css-color-keywords": "^1.0.0",
+        "postcss-value-parser": "^4.0.2"
+      }
     },
     "node_modules/css-tree": {
       "version": "3.1.0",
@@ -3771,6 +3855,15 @@
       "integrity": "sha512-EC+0oUMY1Rqm4O6LLrgjtYDvcVYTy7chDnM4Q7030tP4Kwj3u/pR6gP9ygnp2CJMK5Gq+9Q2oqmrFJAz01DXjw==",
       "license": "MIT"
     },
+    "node_modules/emoji-regex-xs": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/emoji-regex-xs/-/emoji-regex-xs-2.0.1.tgz",
+      "integrity": "sha512-1QFuh8l7LqUcKe24LsPUNzjrzJQ7pgRwp1QMcZ5MX6mFplk2zQ08NVCM84++1cveaUUYtcCYHmeFEuNg16sU4g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/enhanced-resolve": {
       "version": "5.18.2",
       "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.18.2.tgz",
@@ -3882,6 +3975,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
     },
     "node_modules/escape-string-regexp": {
       "version": "5.0.0",
@@ -4047,6 +4146,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/fflate": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.7.4.tgz",
+      "integrity": "sha512-5u2V/CDW15QM1XbbgS+0DfPxVB+jUKhWEKuuFuHncbk3tEEqzmoXL+2KyOFuKGqOnmdIy0/davWF1CkuwtibCw==",
+      "license": "MIT"
     },
     "node_modules/flattie": {
       "version": "1.1.1",
@@ -4534,6 +4639,18 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hex-rgb": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/hex-rgb/-/hex-rgb-4.3.0.tgz",
+      "integrity": "sha512-Ox1pJVrDCyGHMG9CFg1tmrRUMRPRsAWYc/PinY0XzJU4K7y7vjNoLKIQ7BR5UJMCxNN8EM1MNDmHWA/B3aZUuw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/html-escaper": {
@@ -5052,6 +5169,25 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/linebreak": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/linebreak/-/linebreak-1.1.0.tgz",
+      "integrity": "sha512-MHp03UImeVhB7XZtjd0E4n6+3xr5Dq/9xI/5FptGk5FrbDR3zagPa2DS6U8ks/3HjbKWG9Q1M2ufOzxV2qLYSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "0.0.8",
+        "unicode-trie": "^2.0.0"
+      }
+    },
+    "node_modules/linebreak/node_modules/base64-js": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz",
+      "integrity": "sha512-3XSA2cR/h/73EzlXXdU6YNycmYI7+kicTxks4eJg2g39biHR84slg2+des+p7iHYhbRg/udIS4TD53WabcOUkw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/linkify-it": {
@@ -6506,6 +6642,16 @@
       "integrity": "sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA==",
       "license": "MIT"
     },
+    "node_modules/parse-css-color": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/parse-css-color/-/parse-css-color-0.2.1.tgz",
+      "integrity": "sha512-bwS/GGIFV3b6KS4uwpzCFj4w297Yl3uqnSgIPsoQkx7GMLROXfMnWvxfNkL0oh8HVhZA4hvJoEoEIqonfJ3BWg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "^1.1.4",
+        "hex-rgb": "^4.1.0"
+      }
+    },
     "node_modules/parse-entities": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-4.0.2.tgz",
@@ -6663,6 +6809,12 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/postcss-value-parser": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+      "license": "MIT"
     },
     "node_modules/prismjs": {
       "version": "1.30.0",
@@ -7241,6 +7393,37 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/satori": {
+      "version": "0.26.0",
+      "resolved": "https://registry.npmjs.org/satori/-/satori-0.26.0.tgz",
+      "integrity": "sha512-tkMFrfIs3l2mQ2JEcyW0ADTy3zGggFRFzi6Ef8YozQSFsFKEqaSO1Y8F9wJg4//PJGQauMalHGTUEkPrFwhVPA==",
+      "license": "MPL-2.0",
+      "dependencies": {
+        "@shuding/opentype.js": "1.4.0-beta.0",
+        "css-background-parser": "^0.1.0",
+        "css-box-shadow": "1.0.0-3",
+        "css-gradient-parser": "^0.0.17",
+        "css-to-react-native": "^3.0.0",
+        "emoji-regex-xs": "^2.0.1",
+        "escape-html": "^1.0.3",
+        "linebreak": "^1.1.0",
+        "parse-css-color": "^0.2.1",
+        "postcss-value-parser": "^4.2.0",
+        "yoga-layout": "^3.2.1"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/satori-html": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/satori-html/-/satori-html-0.3.2.tgz",
+      "integrity": "sha512-wjTh14iqADFKDK80e51/98MplTGfxz2RmIzh0GqShlf4a67+BooLywF17TvJPD6phO0Hxm7Mf1N5LtRYvdkYRA==",
+      "license": "MIT",
+      "dependencies": {
+        "ultrahtml": "^1.2.0"
+      }
+    },
     "node_modules/sax": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
@@ -7427,6 +7610,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/string.prototype.codepointat": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/string.prototype.codepointat/-/string.prototype.codepointat-0.2.1.tgz",
+      "integrity": "sha512-2cBVCj6I4IOvEnjgO/hWqXjqBGsY+zwPmHl12Srk9IXSZ56Jwwmy+66XO5Iut/oQVR7t5ihYdLB0GMa4alEUcg==",
+      "license": "MIT"
     },
     "node_modules/stringify-entities": {
       "version": "4.0.4",
@@ -8153,6 +8342,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/yoga-layout": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/yoga-layout/-/yoga-layout-3.2.1.tgz",
+      "integrity": "sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ==",
+      "license": "MIT"
     },
     "node_modules/zod": {
       "version": "3.25.76",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@astrojs/rss": "^4.0.12",
     "@astrojs/sitemap": "^3.7.2",
     "@astrojs/starlight": "^0.35.2",
+    "@fontsource/inter": "^5.2.8",
     "@headlessui/react": "^2.2.0",
     "@tailwindcss/typography": "^0.5.16",
     "@tailwindcss/vite": "^4.1.11",
@@ -28,6 +29,8 @@
     "rehype-autolink-headings": "^7.1.0",
     "rehype-slug": "^6.0.0",
     "sanitize-html": "^2.13.0",
+    "satori": "^0.26.0",
+    "satori-html": "^0.3.2",
     "sharp": "^0.34.5",
     "tailwindcss": "^4.0.0",
     "ultrahtml": "^1.5.3"

--- a/src/layouts/ReleasesLayout.astro
+++ b/src/layouts/ReleasesLayout.astro
@@ -1,16 +1,25 @@
 ---
 import BaseLayout from "./BaseLayout.astro";
-import releaseCard from "../content/releases/assets/releases-card.jpeg";
 import "../styles/global.css";
 import "../styles/anchor-links.css";
 
-const { title, description } = Astro.props;
+interface Props {
+  title: string;
+  description: string;
+  image?: string;
+}
+
+const {
+  title,
+  description,
+  image = "/images/social/card-summary-large.png",
+} = Astro.props as Props;
 ---
 
 <BaseLayout
   title={title}
   description={description}
-  image={releaseCard.src}
+  image={image}
   twitterCardType="summary_large_image"
 >
   <slot name="head" slot="head">
@@ -18,7 +27,6 @@ const { title, description } = Astro.props;
       rel="alternate"
       type="application/rss+xml"
       title="Operately Releases"
-      why
       href={new URL("/releases/rss.xml", Astro.site)}
     />
     <!-- we can't use `head` in further pages as it would override the above, hence a new slot -->

--- a/src/pages/releases/[...slug].astro
+++ b/src/pages/releases/[...slug].astro
@@ -1,6 +1,7 @@
 ---
 import ReleasesLayout from "../../layouts/ReleasesLayout.astro";
 import { getPublishedReleases } from "../../utils/releases";
+import { releaseOgImagePath } from "../../utils/releaseOgImage";
 import { ChevronLeft, ChevronRight } from "lucide-react";
 import { YouTubeEmbed } from "../../components/YouTubeEmbed";
 
@@ -27,7 +28,9 @@ const formatDate = (date) => {
   });
 };
 
-const canonicalURL = new URL(`/releases/${entry.slug}/`, Astro.site);
+const releasePathname = Astro.url.pathname;
+const canonicalURL = new URL(releasePathname, Astro.site);
+const ogImagePath = releaseOgImagePath(releasePathname);
 const breadcrumbId = `${canonicalURL.toString()}#breadcrumb`;
 
 const jsonLd = JSON.stringify({
@@ -83,7 +86,7 @@ const jsonLd = JSON.stringify({
 <ReleasesLayout
   title={entry.data.title}
   description={entry.data.description}
-  youtubeId={entry.data.youtubeId}
+  image={ogImagePath}
 >
   <Fragment slot="head-releases">
     <meta name="author" content="Operately Team" />

--- a/src/pages/releases/[...slug]/og.png.ts
+++ b/src/pages/releases/[...slug]/og.png.ts
@@ -1,0 +1,30 @@
+import type { APIRoute } from "astro";
+import { getPublishedReleases } from "../../../utils/releases";
+import {
+  generateReleaseOgImage,
+  type ReleaseOgImageInput,
+} from "../../../utils/releaseOgImage";
+
+export async function getStaticPaths() {
+  const releases = await getPublishedReleases();
+
+  return releases.map((entry) => ({
+    params: { slug: entry.slug },
+    props: {
+      title: entry.data.title,
+      version: entry.data.version,
+      date: entry.data.date,
+    } satisfies ReleaseOgImageInput,
+  }));
+}
+
+export const GET: APIRoute = async ({ props }) => {
+  const png = await generateReleaseOgImage(props as ReleaseOgImageInput);
+
+  return new Response(png, {
+    headers: {
+      "Content-Type": "image/png",
+      "Cache-Control": "public, max-age=31536000, immutable",
+    },
+  });
+};

--- a/src/pages/releases/index.astro
+++ b/src/pages/releases/index.astro
@@ -1,6 +1,7 @@
 ---
 import ReleasesLayout from "../../layouts/ReleasesLayout.astro";
 import { getPublishedReleases } from "../../utils/releases";
+import { releaseOgImagePath } from "../../utils/releaseOgImage";
 import { Rss, Link } from "lucide-react";
 import "../../styles/anchor-links.css";
 
@@ -24,6 +25,7 @@ const { Content: LatestReleaseContent } = latestRelease
 <ReleasesLayout
   title="Operately Releases"
   description="All product releases and updates from Operately"
+  image={latestRelease ? releaseOgImagePath(`/releases/${latestRelease.slug}/`) : undefined}
 >
   <h1 class="text-4xl font-bold mb-8">Operately Releases</h1>
 

--- a/src/utils/releaseOgImage.ts
+++ b/src/utils/releaseOgImage.ts
@@ -1,0 +1,186 @@
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import satori from "satori";
+import { html } from "satori-html";
+import sharp from "sharp";
+
+const OG_WIDTH = 1200;
+const OG_HEIGHT = 630;
+const BRAND_BLUE = "#0055FF";
+const MUTED_WHITE = "rgba(255, 255, 255, 0.72)";
+
+const wordmarkPath = join(process.cwd(), "src/layouts/operately-logo.svg");
+const fontsDir = join(process.cwd(), "node_modules/@fontsource/inter/files");
+
+let fontsPromise: Promise<
+  { name: string; data: Buffer; weight: 400 | 600 | 700; style: "normal" }[]
+> | null = null;
+let wordmarkDataUrlPromise: Promise<string> | null = null;
+
+async function loadFonts() {
+  if (!fontsPromise) {
+    fontsPromise = Promise.all([
+      readFile(`${fontsDir}/inter-latin-400-normal.woff`),
+      readFile(`${fontsDir}/inter-latin-600-normal.woff`),
+      readFile(`${fontsDir}/inter-latin-700-normal.woff`),
+    ]).then(([regular, semibold, bold]) => [
+      { name: "Inter", data: regular, weight: 400 as const, style: "normal" as const },
+      { name: "Inter", data: semibold, weight: 600 as const, style: "normal" as const },
+      { name: "Inter", data: bold, weight: 700 as const, style: "normal" as const },
+    ]);
+  }
+  return fontsPromise;
+}
+
+/** Full Operately wordmark (icon + text) from operately-logo.svg, recolored to white. */
+async function loadWordmarkDataUrl() {
+  if (!wordmarkDataUrlPromise) {
+    wordmarkDataUrlPromise = readFile(wordmarkPath, "utf8").then((svg) => {
+      const whiteSvg = svg.replace(/fill="#(?:262626|024FAC|3185FF)"/g, 'fill="#ffffff"');
+      return `data:image/svg+xml;base64,${Buffer.from(whiteSvg).toString("base64")}`;
+    });
+  }
+  return wordmarkDataUrlPromise;
+}
+
+/** Safe text for satori-html — do not encode & (shows as literal &amp; otherwise). */
+function sanitizeText(value: string) {
+  return value
+    .replaceAll("&amp;", "&")
+    .replaceAll("&lt;", "<")
+    .replaceAll("&gt;", ">")
+    .replaceAll("&quot;", '"')
+    .replaceAll("&#39;", "'")
+    .replaceAll(/[<>]/g, "");
+}
+
+function titleFontSize(title: string) {
+  if (title.length > 100) return 38;
+  if (title.length > 80) return 42;
+  if (title.length > 55) return 48;
+  if (title.length > 35) return 54;
+  return 58;
+}
+
+function formatReleaseDate(date: Date) {
+  return date.toLocaleDateString("en-US", {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+  });
+}
+
+export type ReleaseOgImageInput = {
+  title: string;
+  version: string;
+  date: Date;
+};
+
+/** Build OG image URL from a release page pathname (e.g. `/releases/v160/`). */
+export function releaseOgImagePath(releasePagePathname: string) {
+  const normalized = releasePagePathname.replace(/\/$/, "");
+  return `${normalized}/og.png`;
+}
+
+export async function generateReleaseOgImage({
+  title,
+  version,
+  date,
+}: ReleaseOgImageInput): Promise<Buffer> {
+  const [fonts, wordmarkDataUrl] = await Promise.all([loadFonts(), loadWordmarkDataUrl()]);
+  const safeTitle = sanitizeText(title);
+  const safeVersion = sanitizeText(`Operately v${version}`);
+  const safeDate = sanitizeText(formatReleaseDate(date));
+  const headlineSize = titleFontSize(title);
+
+  const markup = html(`
+    <div
+      style="
+        width: 100%;
+        height: 100%;
+        display: flex;
+        flex-direction: column;
+        background-color: ${BRAND_BLUE};
+        color: #ffffff;
+        font-family: Inter;
+        padding: 56px 72px 52px;
+      "
+    >
+      <div
+        style="
+          display: flex;
+          align-items: center;
+          justify-content: space-between;
+          width: 100%;
+        "
+      >
+        <img
+          src="${wordmarkDataUrl}"
+          style="display: block; height: 36px; width: 202px;"
+        />
+        <div
+          style="
+            font-size: 22px;
+            font-weight: 400;
+            color: ${MUTED_WHITE};
+          "
+        >
+          ${safeDate}
+        </div>
+      </div>
+
+      <div
+        style="
+          display: flex;
+          flex-direction: column;
+          gap: 16px;
+          max-width: 1000px;
+          flex: 1;
+          justify-content: center;
+          padding-top: 8px;
+          padding-bottom: 8px;
+        "
+      >
+        <div
+          style="
+            font-size: ${headlineSize}px;
+            font-weight: 700;
+            line-height: 1.2;
+            letter-spacing: -0.03em;
+            color: #ffffff;
+          "
+        >
+          ${safeTitle}
+        </div>
+        <div
+          style="
+            font-size: 32px;
+            font-weight: 400;
+            line-height: 1.3;
+            color: ${MUTED_WHITE};
+          "
+        >
+          ${safeVersion}
+        </div>
+      </div>
+
+      <div
+        style="
+          font-size: 22px;
+          font-weight: 400;
+          color: ${MUTED_WHITE};
+        "
+      >
+        operately.com
+      </div>
+    </div>
+  `);
+
+  const svg = await satori(markup, {
+    width: OG_WIDTH,
+    height: OG_HEIGHT,
+    fonts,
+  });
+
+  return sharp(Buffer.from(svg)).png().toBuffer();
+}


### PR DESCRIPTION
Generate per-release social cards at build time with Satori, using the Operately wordmark and release title/version from content frontmatter.